### PR TITLE
Tensorflow GPU installation in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.10.12,<3.12"
-dm-reverb = {extras = ["tensorflow"], version = "^0.14.0"}
+tensorflow = "2.15.1"
+dm-reverb = "^0.14.0"
 pytz = "^2024.1"
 gin-config = "^0.5.0"
 matplotlib = "^3.9.2"


### PR DESCRIPTION
Changed pyproject.toml so tensorflow is now installed separately from dm-reverb and will now support GPU.