### PR TITLE
Fix failing tests + Add Github Actions workflow to test setup instructions + run test suite

### DIFF
--- a/.github/workflows/setup-test.yaml
+++ b/.github/workflows/setup-test.yaml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - master
+      - copybara_push
 
 jobs:
   test:

--- a/.github/workflows/setup-test.yaml
+++ b/.github/workflows/setup-test.yaml
@@ -1,0 +1,42 @@
+name: Python CI
+
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest  # Use an Ubuntu runner for the job
+
+    strategy:
+      matrix:
+        python-version: [3.10.12, 3.10.15, 3.11]  # Python versions to test
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4  # Checks out the repository's code
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}  # Use Python version from the matrix
+
+    - name: Install system dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y protobuf-compiler ffmpeg  # Install both protobuf and ffmpeg in one step
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m venv .venv
+        source .venv/bin/activate
+        pip install poetry
+        poetry install
+    
+    - name: Run tests
+      run: |
+        source .venv/bin/activate
+        pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ scikit-learn = "^1.5.1"
 ipykernel = "^6.29.5"
 typing-extensions = "^4.12.2"
 ipython = "^8.27.0"
+pytest = "^8.3.3"
 
 
 [build-system]

--- a/smart_control/simulator/building_utils_test.py
+++ b/smart_control/simulator/building_utils_test.py
@@ -17,11 +17,13 @@ limitations under the License.
 
 import os
 
+from absl import flags
 from absl.testing import absltest
 from absl.testing import parameterized
 import numpy as np
 from smart_control.simulator import building_utils
 
+flags.FLAGS([""]) # Required to avoid error with create_tempdir
 
 class BuildingUtilsTest(parameterized.TestCase):
 

--- a/smart_control/utils/controller_read_write_test.py
+++ b/smart_control/utils/controller_read_write_test.py
@@ -20,6 +20,7 @@ import operator
 import os
 
 from absl.testing import absltest
+from absl import flags
 import pandas as pd
 from smart_control.proto import smart_control_building_pb2
 from smart_control.proto import smart_control_normalization_pb2
@@ -27,6 +28,9 @@ from smart_control.proto import smart_control_reward_pb2
 from smart_control.utils import controller_reader
 from smart_control.utils import controller_writer
 from smart_control.utils import conversion_utils
+
+
+flags.FLAGS([""]) # Required to avoid error with create_tempdir
 
 
 class ControllerReadWriteTest(absltest.TestCase):


### PR DESCRIPTION
This PR has two commits:

1. fix: address failing tests in building_utils_test and controller_read write_test; add pytest to poetry dependencies
- Add `pytest` to poetry dependencies
- Fix failing tests on `building_utils_test.py` and `controller_read write_test.py`.



2. feat: add github actions workflow to test setup instructions + run test suite on push to any branch + PRs to master
- Add `setup-test.yaml` workflow, which test setup instructions and then runs the test suite on push to any branch + PRs to master. This should indicate if there are any breaking changes about to be merged, and help make sure that setup instructions are always up to date. 