### PR TITLE
Pre-submit Checks: Unused References

### DIFF
--- a/SBSIM_OVERVIEW.md
+++ b/SBSIM_OVERVIEW.md
@@ -123,7 +123,6 @@ The `environment` module provides the reinforcement learning environment where t
 
             *   `_get_action_spec_and_normalizers(...)`: Defines the action space and normalizers based on the building devices and action configurations.
             *   `_get_observation_spec(...)`: Defines the observation space based on the building devices and observation configurations.
-            *   `_format_action(action, action_names)`: Reformat actions if necessary (extension point for subclasses).
             *   `render(mode)`: (Not implemented) Intended for rendering the environment state.
         *   **Properties**:
 

--- a/smart_control/environment/environment.py
+++ b/smart_control/environment/environment.py
@@ -1217,12 +1217,6 @@ class Environment(py_environment.PyEnvironment):
   def observation_spec(self) -> types.NestedArraySpec:
     return self._observation_spec
 
-  def _format_action(
-      self, action: types.NestedArray, action_names: Sequence[str]
-  ) -> types.NestedArray:
-    """Enables extension classes to reformat actions into base format."""
-    return action
-
   def _step(self, action: types.NestedArray) -> ts.TimeStep:
     """Individual time step calculations.
 
@@ -1253,9 +1247,6 @@ class Environment(py_environment.PyEnvironment):
     t0 = time.time()
     reward_value = 0.0
     observation = None
-
-    # Reformat actions if necessary.
-    action = self._format_action(action, self._action_names)
 
     # Convert the action from normalized to native values.
     action_request = self._create_action_request(action)

--- a/smart_control/environment/environment.py
+++ b/smart_control/environment/environment.py
@@ -1253,7 +1253,6 @@ class Environment(py_environment.PyEnvironment):
     t0 = time.time()
     reward_value = 0.0
     observation = None
-    last_timestamp = self.current_simulation_timestamp
 
     # Reformat actions if necessary.
     action = self._format_action(action, self._action_names)
@@ -1308,7 +1307,7 @@ class Environment(py_environment.PyEnvironment):
 
     # Exit when the episode has ended and return terminal step information.
     # We still need to get the final observation to add to the transition.
-    self._episode_ended = self._has_episode_ended(last_timestamp)
+    self._episode_ended = self._has_episode_ended()
 
     self._episode_cumulative_reward += reward_value
 
@@ -1360,7 +1359,7 @@ class Environment(py_environment.PyEnvironment):
   def render(self, mode: str = "rgb_array") -> Optional[types.NestedArray]:
     raise NotImplementedError("Rendering not supported yet.")
 
-  def _has_episode_ended(self, last_timestamp: pd.Timestamp) -> bool:
+  def _has_episode_ended(self) -> bool:
     """Flag to indicate the episode has ended."""
 
     return self._step_count >= self._num_timesteps_in_episode

--- a/smart_control/reinforcement_learning/agents/networks/sac_networks.py
+++ b/smart_control/reinforcement_learning/agents/networks/sac_networks.py
@@ -112,7 +112,7 @@ class _TanhNormalProjectionNetworkWrapper(
     super(_TanhNormalProjectionNetworkWrapper, self).__init__(sample_spec)
     self.predefined_outer_rank = predefined_outer_rank
 
-  def call(self, inputs, network_state=(), **kwargs):
+  def call(self, inputs, **kwargs):
     kwargs['outer_rank'] = self.predefined_outer_rank
     if 'step_type' in kwargs:
       del kwargs['step_type']

--- a/smart_control/reinforcement_learning/scripts/populate_starter_buffer.py
+++ b/smart_control/reinforcement_learning/scripts/populate_starter_buffer.py
@@ -11,7 +11,6 @@ import tensorflow as tf
 from tf_agents.environments import tf_py_environment
 from tf_agents.policies import py_tf_eager_policy
 from tf_agents.train import actor
-from tf_agents.train.utils import spec_utils
 from tf_agents.trajectories import trajectory
 
 from smart_control.reinforcement_learning.observers.composite_observer import CompositeObserver

--- a/smart_control/reinforcement_learning/scripts/populate_starter_buffer.py
+++ b/smart_control/reinforcement_learning/scripts/populate_starter_buffer.py
@@ -78,9 +78,6 @@ def populate_replay_buffer(
 
   # Create policy for collection
   train_step = tf.Variable(0, trainable=False, dtype=tf.int64)
-  observation_spec, action_spec, time_step_spec = spec_utils.get_tensor_specs(
-      collect_tf_env
-  )
 
   collection_policy = create_baseline_schedule_policy(collect_tf_env)
 

--- a/smart_control/reinforcement_learning/scripts/populate_starter_buffer.py
+++ b/smart_control/reinforcement_learning/scripts/populate_starter_buffer.py
@@ -11,6 +11,7 @@ import tensorflow as tf
 from tf_agents.environments import tf_py_environment
 from tf_agents.policies import py_tf_eager_policy
 from tf_agents.train import actor
+from tf_agents.train.utils import spec_utils
 from tf_agents.trajectories import trajectory
 
 from smart_control.reinforcement_learning.observers.composite_observer import CompositeObserver
@@ -77,6 +78,8 @@ def populate_replay_buffer(
 
   # Create policy for collection
   train_step = tf.Variable(0, trainable=False, dtype=tf.int64)
+
+  _, action_spec, time_step_spec = spec_utils.get_tensor_specs(collect_tf_env)
 
   collection_policy = create_baseline_schedule_policy(collect_tf_env)
 

--- a/smart_control/reinforcement_learning/utils/config.py
+++ b/smart_control/reinforcement_learning/utils/config.py
@@ -6,6 +6,7 @@ from typing import Any
 import gin
 import numpy as np
 
+# pylint: disable=unused-import
 # the following imports are necessary for proper gin setup, even if they aren't referenced
 # do not remove
 from smart_control.reward.electricity_energy_cost import ElectricityEnergyCost
@@ -25,6 +26,8 @@ from smart_control.utils import histogram_reducer
 from smart_control.utils.controller_writer import ProtoWriterFactory
 from smart_control.utils.environment_utils import to_timestamp
 from smart_control.utils.observation_normalizer import StandardScoreObservationNormalizer
+
+# pylint: enable=unused-import
 
 # Path to the root directory of the project:
 ROOT_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "..")

--- a/smart_control/reinforcement_learning/utils/metrics.py
+++ b/smart_control/reinforcement_learning/utils/metrics.py
@@ -47,7 +47,6 @@ def compute_avg_return(
     policy: py_policy.PyPolicy,
     num_episodes: int = 1,
     time_zone: str = DEFAULT_TIME_ZONE,
-    render_interval_steps: int = 24,
     trajectory_observers: Optional[List[Callable]] = None,
     num_steps: int = 6,
 ) -> Tuple[float, List[List[Any]]]:
@@ -58,7 +57,6 @@ def compute_avg_return(
       policy: Policy to evaluate.
       num_episodes: Total number of episodes to run.
       time_zone: Time zone for timestamps.
-      render_interval_steps: Number of steps between renderings.
       trajectory_observers: List of trajectory observers.
       num_steps: Number of steps to take per episode.
 

--- a/smart_control/simulator/stochastic_occupancy.py
+++ b/smart_control/simulator/stochastic_occupancy.py
@@ -126,7 +126,6 @@ class ZoneOccupant:
     return values[index]
 
   def _sample_lunch_duration(self):
-    duration_minutes = np.arange(30, 91, 5)
     values, cumulative_probabilities = self._generate_cpf(30, 90)
     random_value = self._random_state.rand()
     index = np.searchsorted(cumulative_probabilities, random_value)

--- a/smart_control/simulator/stochastic_occupancy_test.py
+++ b/smart_control/simulator/stochastic_occupancy_test.py
@@ -15,9 +15,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import sys
-
-from absl import flags
 from absl.testing import absltest
 from absl.testing import parameterized
 import numpy as np

--- a/smart_control/simulator/stochastic_occupancy_test.py
+++ b/smart_control/simulator/stochastic_occupancy_test.py
@@ -95,7 +95,6 @@ class LIGHTSWITCHOccupancyTest(parameterized.TestCase):
 
     while current_time < pd.Timestamp('2021-09-01 23:00', tz=tz):
       state = occupant.peek(current_time=current_time)
-      local_time = occupant._to_local_time(current_time) if tz else current_time
 
       # Debugging information
       # print(f"Current time: {current_time}, Local time: {local_time}")


### PR DESCRIPTION
Update files to make pre-submit checks pass, so we can merge the code into Google.

Addresses Unused Reference-related linting checks: 

  + unused-import (W0611)
  + unused-variable (W0612)
  + unused-argument (W0613)

Notes:

  +  Removes a `_format_action` function from the base `Environment` class that is now-unused by any child classes in this codebase, as a result of removing unused variable references. There is a reference to a `_format_action` function in a child class in the Google codebase, but that class (`HybridActionEnvironment`) defines its own `_format_action` function, so this function in the parent class is confirmed as unnecessary.
  + Removes an unused argument `network_state` from the `call` function in the `_TanhNormalProjectionNetworkWrapper` class. The parent class (`TanhNormalProjectionNetwork` from tf-agents) does not use a `network_state` in its `call` function, so we confirm we can remove this unused arg.
 