### PR TITLE
Pre-submit Checks: Docstring Formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ To check for a specific issue (e.g. "missing-module-docstring"), using the corre
 pylint smart_control --ignore=proto --disable=all --enable=C0114
 ```
 
+> NOTE: some error messages beginning with "g-" are additional Google-specific errors that may need to be checked using internal tools (`gpylint`), and may not be able to be checked by open source contributors at this time.
+
 If you would like to prevent certain lines of code from being checked (for example to leave a long line as-is), it is possible to [ignore formatting](hhttps://pylint.readthedocs.io/en/stable/user_guide/messages/message_control.html#block-disables) by adding `pylint` pragma comments like `# pylint: disable=line-too-long`. NOTE: `pylint` and `pyink` (see section above) may each require their own set of separate pragma comments.
 
 

--- a/smart_control/reinforcement_learning/observers/rendering_observer.py
+++ b/smart_control/reinforcement_learning/observers/rendering_observer.py
@@ -54,7 +54,6 @@ class RenderingObserver(Observer):
     """Initialize the observer.
 
     Args:
-        metrics_path: Path to metrics directory.
         render_interval_steps: Number of steps between renders.
         environment: The environment to render. This must support the
           current_simulation_timestamp property if plot_fn is specified.

--- a/smart_control/reinforcement_learning/policies/schedule_policy.py
+++ b/smart_control/reinforcement_learning/policies/schedule_policy.py
@@ -186,7 +186,9 @@ class SchedulePolicy(tf_policy.TFPolicy):
     return policy_step.PolicyStep(tf.convert_to_tensor(action_array), (), ())
 
 
-def create_baseline_schedule_policy(tf_env: tf_env.TFPyEnvironment):
+def create_baseline_schedule_policy(
+    tf_env: tf_env.TFPyEnvironment,
+) -> SchedulePolicy:
   """Create baseline schedule policy.
 
   This is the baseline default policy that we use for benchmarking /
@@ -194,6 +196,9 @@ def create_baseline_schedule_policy(tf_env: tf_env.TFPyEnvironment):
 
   Args:
     tf_env: The TFPyEnvironment to interact with.
+
+  Returns:
+    The schedule policy.
   """
   env = tf_env.pyenv.envs[0]
 

--- a/smart_control/reinforcement_learning/policies/schedule_policy.py
+++ b/smart_control/reinforcement_learning/policies/schedule_policy.py
@@ -191,6 +191,9 @@ def create_baseline_schedule_policy(tf_env: tf_env.TFPyEnvironment):
 
   This is the baseline default policy that we use for benchmarking /
   initial data collection.
+
+  Args:
+    tf_env: The TFPyEnvironment to interact with.
   """
   env = tf_env.pyenv.envs[0]
 

--- a/smart_control/reinforcement_learning/scripts/populate_starter_buffer.py
+++ b/smart_control/reinforcement_learning/scripts/populate_starter_buffer.py
@@ -40,13 +40,16 @@ def populate_replay_buffer(
   """Populates a replay buffer with initial exploration data.
 
   Args:
-      buffer_name: Name with which to save replay buffer. Buffer will be at
-        smart_control/reinforcement_learning/data/starter_buffers/{buffer_name}
-      buffer_capacity: Maximum size of the replay buffer
-      steps_per_run: Number of steps per actor run
-      num_runs: Number of actor runs to perform
-      sequence_length: Length of sequences to store in the replay buffer
-      env_gin_config_file_path: Path to the environment configuration file
+    buffer_name: Name with which to save replay buffer. Buffer will be at
+      smart_control/reinforcement_learning/data/starter_buffers/{buffer_name}
+    buffer_capacity: Maximum size of the replay buffer
+    steps_per_run: Number of steps per actor run
+    num_runs: Number of actor runs to perform
+    sequence_length: Length of sequences to store in the replay buffer
+    env_gin_config_file_path: Path to the environment configuration file
+
+  Returns:
+    The replay buffer.
   """
 
   buffer_path = os.path.join(

--- a/smart_control/reinforcement_learning/scripts/train.py
+++ b/smart_control/reinforcement_learning/scripts/train.py
@@ -55,17 +55,20 @@ def train_agent(
   Trains a reinforcement learning agent using a pre-populated replay buffer.
 
   Args:
-      starter_buffer_path: Path to the pre-populated replay buffer
-      experiment_name: Name of the experiment - used to name the experiment results directory
-      agent_type: Type of agent to train ('sac' or 'td3')
-      train_iterations: Number of training iterations
-      collect_steps_per_iteration: Number of collection steps per training iteration
-      batch_size: Batch size for training
-      log_interval: Interval for logging training metrics
-      eval_interval: Interval for evaluating the agent
-      num_eval_episodes: Number of episodes for evaluation
-      checkpoint_interval: Interval for checkpointing the replay buffer
-      learner_iterations: Number of iterations to run the agent learner per training loop
+    starter_buffer_path: Path to the pre-populated replay buffer
+    experiment_name: Name of the experiment - used to name the experiment results directory
+    agent_type: Type of agent to train ('sac' or 'td3')
+    train_iterations: Number of training iterations
+    collect_steps_per_iteration: Number of collection steps per training iteration
+    batch_size: Batch size for training
+    log_interval: Interval for logging training metrics
+    eval_interval: Interval for evaluating the agent
+    num_eval_episodes: Number of episodes for evaluation
+    checkpoint_interval: Interval for checkpointing the replay buffer
+    learner_iterations: Number of iterations to run the agent learner per training loop
+
+  Returns:
+    The trained agent.
   """
   # Set up scenario config path
   scenario_config_path = os.path.join(CONFIG_PATH, 'sim_config_1_day.gin')

--- a/smart_control/reinforcement_learning/scripts/train.py
+++ b/smart_control/reinforcement_learning/scripts/train.py
@@ -56,6 +56,7 @@ def train_agent(
 
   Args:
       starter_buffer_path: Path to the pre-populated replay buffer
+      experiment_name: Name of the experiment - used to name the experiment results directory
       agent_type: Type of agent to train ('sac' or 'td3')
       train_iterations: Number of training iterations
       collect_steps_per_iteration: Number of collection steps per training iteration
@@ -358,7 +359,7 @@ if __name__ == '__main__':
       '--experiment-name',
       type=str,
       required=True,
-      help='Name of the experiment. This be used to save TensorBoard summaries',
+      help='Name of the experiment. This is used to save TensorBoard summaries',
   )
   parser.add_argument(
       '--checkpoint-interval',

--- a/smart_control/reinforcement_learning/scripts/train.py
+++ b/smart_control/reinforcement_learning/scripts/train.py
@@ -1,5 +1,5 @@
-"""
-Script to train a reinforcement learning agent using a pre-populated replay buffer.
+"""Script to train a reinforcement learning agent using a pre-populated replay buffer.
+
 This script sets up the training process with separate collection and evaluation components.
 """
 
@@ -51,8 +51,7 @@ def train_agent(
     checkpoint_interval=1000,  # New parameter for checkpointing frequency
     learner_iterations=200,  # New parameter for learner iterations per loop
 ):
-  """
-  Trains a reinforcement learning agent using a pre-populated replay buffer.
+  """Trains a reinforcement learning agent using a pre-populated replay buffer.
 
   Args:
     starter_buffer_path: Path to the pre-populated replay buffer


### PR DESCRIPTION
Update files to make pre-submit checks pass, so we can merge the code into Google.

Addresses Docstring Formatting -related linting checks: 

  + g-doc-args (C6113)
  + g-doc-return-or-yield (C6112)
  + g-space-before-docstring-summary (C6109)

Notes:

  + We needed to use the internal `gpylint` tool to check for these Google-specific errors. We have created issue #40 to encourage us to find a way for open source contributors to run these checks in the future.