### PR TITLE
Pre-submit Checks: Protected Access

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -19,7 +19,7 @@ persistent=no
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
-load-plugins=
+load-plugins=pylint_per_file_ignores
 
 # Use multiple processes to speed up Pylint.
 jobs=4
@@ -129,6 +129,37 @@ disable=R,
         wrong-import-order,
         xrange-builtin,
         zip-builtin-not-iterating,
+
+# Ignore "protected-access" errors in test files only.
+#per-file-ignores =
+#    test_.*.py:protected-access
+#    .*_test\.py:protected-access
+
+# Define per-file ignores using the loaded plugin
+# Format is: <file_pattern>:<message_id_or_symbol>[,<message_id_or_symbol>...]
+# Use separate lines for different patterns or groups of messages.
+#per-file-ignores =
+#  test_*.py:W0212   # Ignore protected-access in files starting with test_
+#  *_test.py:W0212   # Ignore protected-access in files ending with _test.py
+
+# this works for specific files:
+#per-file-ignores =
+#  smart_control/environment/environment_test.py:protected-access
+#  smart_control/reward/base_setpoint_energy_carbon_reward_test.py:protected-access
+
+# NOPE:
+
+#per-file-ignores=test_*.py:W0212,*_test.py:W0212
+#> astroid.exceptions.AstroidError
+
+#per-file-ignores = regexp:^(test_.*|.*_test)\.py$:W0212
+#> ValueError: dictionary update sequence element #0 has length 3; 2 is required
+
+#per-file-ignores = **/*_test.py:protected-access
+# valid but not matching
+
+#per-file-ignores = **/*_test\.py:protected-access
+
 
 
 [REPORTS]

--- a/.pylintrc
+++ b/.pylintrc
@@ -130,36 +130,11 @@ disable=R,
         xrange-builtin,
         zip-builtin-not-iterating,
 
-# Ignore "protected-access" errors in test files only.
-#per-file-ignores =
-#    test_.*.py:protected-access
-#    .*_test\.py:protected-access
 
-# Define per-file ignores using the loaded plugin
-# Format is: <file_pattern>:<message_id_or_symbol>[,<message_id_or_symbol>...]
-# Use separate lines for different patterns or groups of messages.
-#per-file-ignores =
-#  test_*.py:W0212   # Ignore protected-access in files starting with test_
-#  *_test.py:W0212   # Ignore protected-access in files ending with _test.py
-
-# this works for specific files:
-#per-file-ignores =
-#  smart_control/environment/environment_test.py:protected-access
-#  smart_control/reward/base_setpoint_energy_carbon_reward_test.py:protected-access
-
-# NOPE:
-
-#per-file-ignores=test_*.py:W0212,*_test.py:W0212
-#> astroid.exceptions.AstroidError
-
-#per-file-ignores = regexp:^(test_.*|.*_test)\.py$:W0212
-#> ValueError: dictionary update sequence element #0 has length 3; 2 is required
-
-#per-file-ignores = **/*_test.py:protected-access
-# valid but not matching
-
-#per-file-ignores = **/*_test\.py:protected-access
-
+# Ignore certain errors in certain files
+# see: https://github.com/christopherpickering/pylint-per-file-ignores
+per-file-ignores =
+  .*_test\.py:protected-access # ignore "protected-access" errors in test files
 
 
 [REPORTS]

--- a/poetry.lock
+++ b/poetry.lock
@@ -2434,6 +2434,21 @@ spelling = ["pyenchant (>=3.2,<4.0)"]
 testutils = ["gitpython (>3)"]
 
 [[package]]
+name = "pylint-per-file-ignores"
+version = "1.4.0"
+description = "A pylint plugin to ignore error codes per file."
+optional = false
+python-versions = "<4.0.0,>=3.8.1"
+groups = ["dev"]
+files = [
+    {file = "pylint_per_file_ignores-1.4.0-py3-none-any.whl", hash = "sha256:0cd82d22551738b4e63a0aa1dab2a1fc4016e8f27f1429159616483711e122fd"},
+    {file = "pylint_per_file_ignores-1.4.0.tar.gz", hash = "sha256:c0de7b3d0169571aefaa1ac3a82a265641b8825b54a0b6f5ef27c3b76b988609"},
+]
+
+[package.dependencies]
+tomli = {version = ">=2.0.1,<3.0.0", markers = "python_version < \"3.11\""}
+
+[[package]]
 name = "pyparsing"
 version = "3.2.3"
 description = "pyparsing module - Classes and methods to define and execute parsing grammars"
@@ -3530,4 +3545,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10.12,<3.12"
-content-hash = "e8de5d84b5ae8600f527b95b0357cacd35a3e3e76b78194b6c06410689522564"
+content-hash = "7348bd397b382c41b0165e92fbf0ef918d54805411cce576192d77fa1e5450ef"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ pyink = "^24.10.1"
 pre-commit = "^4.2.0"
 isort = "^6.0.1"
 pylint = "^3.3.6"
+pylint-per-file-ignores = "^1.4.0"
 
 [tool.pyink]
 line-length = 80

--- a/smart_control/environment/environment.py
+++ b/smart_control/environment/environment.py
@@ -442,7 +442,7 @@ class Environment(py_environment.PyEnvironment):
     if self.discount_factor <= 0 or self.discount_factor > 1:
       raise ValueError("Discount factor must be in (0,1]")
 
-    self._metrics_path: Optional[str] = metrics_path
+    self.metrics_path: Optional[str] = metrics_path
     self._writer_factory: Optional[writer_lib.BaseWriterFactory] = (
         writer_factory
     )
@@ -1164,9 +1164,9 @@ class Environment(py_environment.PyEnvironment):
 
     self._metrics_writer = None
 
-    if self._metrics_path and self._writer_factory:
+    if self.metrics_path and self._writer_factory:
       episode_metrics_id = f"{self._label}_{now:%y%m%d_%H%M%S}"
-      output_dir = os.path.join(self._metrics_path, episode_metrics_id)
+      output_dir = os.path.join(self.metrics_path, episode_metrics_id)
 
       logging.info("Writing metric files to %s", output_dir)
       self._metrics_writer = self._writer_factory.create(output_dir)

--- a/smart_control/environment/environment.py
+++ b/smart_control/environment/environment.py
@@ -290,7 +290,7 @@ class ActionConfig:
   """
 
   def __init__(self, action_normalizers: ActionNormalizerMap):
-    self._action_normalizers = action_normalizers
+    self.action_normalizers = action_normalizers
 
   def get_action_normalizer(
       self, setpoint_name: FieldName
@@ -300,7 +300,7 @@ class ActionConfig:
     Args:
       setpoint_name: Name of setpoint to get action normalizer for.
     """
-    return self._action_normalizers.get(DeviceFieldId(setpoint_name))
+    return self.action_normalizers.get(DeviceFieldId(setpoint_name))
 
 
 def generate_field_id(
@@ -458,14 +458,14 @@ class Environment(py_environment.PyEnvironment):
       raise ValueError("Discount factor must be in (0,1]")
 
     if device_action_tuples is not None:
-      self._action_spec, self._action_normalizers, self._action_names = (
+      self._action_spec, self.action_normalizers, self._action_names = (
           self._get_action_spec_and_normalizers_from_device_action_tuples(
               action_config=action_config,
               device_action_tuples=device_action_tuples,
           )
       )
     else:
-      self._action_spec, self._action_normalizers, self._action_names = (
+      self._action_spec, self.action_normalizers, self._action_names = (
           self._get_action_spec_and_normalizers(action_config, building.devices)
       )
 
@@ -575,7 +575,7 @@ class Environment(py_environment.PyEnvironment):
 
       _, setpoint_name = self._id_map.inv[field_id]
       native_setpoint_value = default_actions[setpoint_name]
-      normalized_agent_value = self._action_normalizers[field_id].agent_value(
+      normalized_agent_value = self.action_normalizers[field_id].agent_value(
           native_setpoint_value
       )
       fixed_actions.append(normalized_agent_value)
@@ -846,7 +846,7 @@ class Environment(py_environment.PyEnvironment):
 
       agent_action = action[field_id]
 
-      action_normalizer = self._action_normalizers[field_id]
+      action_normalizer = self.action_normalizers[field_id]
 
       action_value = action_normalizer.setpoint_value(agent_action)
 

--- a/smart_control/environment/environment.py
+++ b/smart_control/environment/environment.py
@@ -476,13 +476,13 @@ class Environment(py_environment.PyEnvironment):
     )
     logging.info("Auxiliary Features %s", self._auxiliary_features)
 
-    self._observation_spec, self._field_names = self._get_observation_spec(
+    self._observation_spec, self.field_names = self._get_observation_spec(
         building.devices
     )
     logging.info("Observation Spec %s", self._observation_spec)
 
-    logging.info("%s FIELD NAMES (%d)", self._label, len(self._field_names))
-    for i, fn in enumerate(self._field_names):
+    logging.info("%s FIELD NAMES (%d)", self._label, len(self.field_names))
+    for i, fn in enumerate(self.field_names):
       logging.info("Field %d: %s", i, fn)
 
     self._episode_ended = False
@@ -945,30 +945,30 @@ class Environment(py_environment.PyEnvironment):
         dtype=np.float32,
     )
     # Return observation as a flat array.
-    if len(self._field_names) > len(observation):
-      dif_set = set(self._field_names) - observation.keys()
+    if len(self.field_names) > len(observation):
+      dif_set = set(self.field_names) - observation.keys()
       dif_set_str = ", ".join(dif_set)
       logging.error("Difference: %s", dif_set_str)
       raise ValueError(
           f"Observation of length ({len(observation)}) is missing"
           f" {len(dif_set)} fields from expected fields size"
-          f" ({len(self._field_names)})."
+          f" ({len(self.field_names)})."
       )
 
     obsarray = np.array(
-        [observation[field_id] for field_id in self._field_names],
+        [observation[field_id] for field_id in self.field_names],
         dtype=np.float32,
     )
     nan_ix = np.squeeze(np.argwhere(np.isnan(obsarray)), axis=1)
     if nan_ix.size > 0:
-      nan_fields = [self._field_names[i] for i in nan_ix]
+      nan_fields = [self.field_names[i] for i in nan_ix]
       logging.warning(
           "Observation vector contains Nans at %s.", ", ".join(nan_fields)
       )
     inf_ix = np.squeeze(np.argwhere(np.isinf(obsarray)), axis=1)
     # TODO(sipple) Add a unit test for the logging below.
     if inf_ix.size > 0:
-      inf_fields = [self._field_names[i] for i in inf_ix]
+      inf_fields = [self.field_names[i] for i in inf_ix]
       logging.warning(
           "Observation vector contains Infs at %s.", ", ".join(inf_fields)
       )

--- a/smart_control/environment/environment.py
+++ b/smart_control/environment/environment.py
@@ -499,7 +499,7 @@ class Environment(py_environment.PyEnvironment):
     # Since the request will not change (i.e., feature vector is fixed),
     # just define a single ObservationRequest as a template for all requests.
     self._observation_request = self._get_observation_request(building.devices)
-    self._occupancy_normalization_constant = occupancy_normalization_constant
+    self.occupancy_normalization_constant = occupancy_normalization_constant
     if run_command_predictors is None:
       self._run_command_predictors = None
     else:
@@ -940,8 +940,8 @@ class Environment(py_environment.PyEnvironment):
         dtype=np.float32,
     )
     observation[NUM_OCCUPANTS] = np.array(
-        (self.building.num_occupants - self._occupancy_normalization_constant)
-        / (self._occupancy_normalization_constant + 1),
+        (self.building.num_occupants - self.occupancy_normalization_constant)
+        / (self.occupancy_normalization_constant + 1),
         dtype=np.float32,
     )
     # Return observation as a flat array.

--- a/smart_control/environment/environment_test.py
+++ b/smart_control/environment/environment_test.py
@@ -349,7 +349,7 @@ class EnvironmentTest(parameterized.TestCase, tf.test.TestCase):
     for i in range(len(env._action_names)):
       field_id = env._action_names[i]
       device, setpoint = env._id_map.inv[field_id]
-      action_normalizer = action_config._action_normalizers[setpoint]
+      action_normalizer = action_config.action_normalizers[setpoint]
       normalized_value = action_normalizer.setpoint_value(action[i])
       expected_request.single_action_requests.append(
           smart_control_building_pb2.SingleActionRequest(

--- a/smart_control/reinforcement_learning/observers/rendering_observer.py
+++ b/smart_control/reinforcement_learning/observers/rendering_observer.py
@@ -514,14 +514,14 @@ class RenderingObserver(Observer):
 
   def _render_env(self, env: environment.Environment, step_count: int):
     """Renders the environment and saves to file."""
-    building_layout = env.building._simulator.building.floor_plan
+    building_layout = env.building.simulator.building.floor_plan
 
     # Create a renderer
     renderer = building_renderer.BuildingRenderer(building_layout, 1)
 
     # Get the current temps to render
-    temps = env.building._simulator.building.temp
-    input_q = env.building._simulator.building.input_q
+    temps = env.building.simulator.building.temp
+    input_q = env.building.simulator.building.input_q
 
     # Render
     vmin = 285

--- a/smart_control/reinforcement_learning/observers/rendering_observer.py
+++ b/smart_control/reinforcement_learning/observers/rendering_observer.py
@@ -514,14 +514,14 @@ class RenderingObserver(Observer):
 
   def _render_env(self, env: environment.Environment, step_count: int):
     """Renders the environment and saves to file."""
-    building_layout = env.building._simulator._building.floor_plan
+    building_layout = env.building._simulator.building.floor_plan
 
     # Create a renderer
     renderer = building_renderer.BuildingRenderer(building_layout, 1)
 
     # Get the current temps to render
-    temps = env.building._simulator._building.temp
-    input_q = env.building._simulator._building.input_q
+    temps = env.building._simulator.building.temp
+    input_q = env.building._simulator.building.input_q
 
     # Render
     vmin = 285

--- a/smart_control/reinforcement_learning/observers/rendering_observer.py
+++ b/smart_control/reinforcement_learning/observers/rendering_observer.py
@@ -514,7 +514,7 @@ class RenderingObserver(Observer):
 
   def _render_env(self, env: environment.Environment, step_count: int):
     """Renders the environment and saves to file."""
-    building_layout = env.building._simulator._building._floor_plan
+    building_layout = env.building._simulator._building.floor_plan
 
     # Create a renderer
     renderer = building_renderer.BuildingRenderer(building_layout, 1)

--- a/smart_control/reinforcement_learning/observers/rendering_observer.py
+++ b/smart_control/reinforcement_learning/observers/rendering_observer.py
@@ -571,9 +571,9 @@ class RenderingObserver(Observer):
           mean_execution_time,
       )
 
-      if self._environment.pyenv.envs[0]._metrics_path is not None:
+      if self._environment.pyenv.envs[0].metrics_path is not None:
         logger.warning('Plotting timeseries charts...')
-        reader = get_latest_episode_reader(self._environment.pyenv.envs[0]._metrics_path)  # pylint: disable=line-too-long
+        reader = get_latest_episode_reader(self._environment.pyenv.envs[0].metrics_path)  # pylint: disable=line-too-long
         self._plot_timeseries_charts(reader, self._time_zone, self._counter)
 
       self._render_env(self._environment.pyenv.envs[0], self._counter)

--- a/smart_control/reinforcement_learning/policies/schedule_policy.py
+++ b/smart_control/reinforcement_learning/policies/schedule_policy.py
@@ -208,11 +208,10 @@ def create_baseline_schedule_policy(
 
   _, action_spec, time_step_spec = spec_utils.get_tensor_specs(tf_env)
 
-  hod_cos_index = env._field_names.index('hod_cos_000')
-  hod_sin_index = env._field_names.index('hod_sin_000')
-  dow_cos_index = env._field_names.index('dow_cos_000')
-  dow_sin_index = env._field_names.index('dow_sin_000')
-
+  hod_cos_index = env.field_names.index('hod_cos_000')
+  hod_sin_index = env.field_names.index('hod_sin_000')
+  dow_cos_index = env.field_names.index('dow_cos_000')
+  dow_sin_index = env.field_names.index('dow_sin_000')
   # Note that temperatures are specified in Kelvin:
   weekday_schedule_events = [
       ScheduleEvent(

--- a/smart_control/reinforcement_learning/policies/schedule_policy.py
+++ b/smart_control/reinforcement_learning/policies/schedule_policy.py
@@ -280,7 +280,7 @@ def create_baseline_schedule_policy(
       ],
       weekday_schedule=weekday_schedule_events,
       weekend_schedule=weekend_holiday_schedule_events,
-      action_normalizers=env._action_normalizers,
+      action_normalizers=env.action_normalizers,
       hod_cos_index=hod_cos_index,
       hod_sin_index=hod_sin_index,
       dow_cos_index=dow_cos_index,

--- a/smart_control/reinforcement_learning/utils/environment.py
+++ b/smart_control/reinforcement_learning/utils/environment.py
@@ -24,7 +24,7 @@ def create_and_setup_environment(
 ):
   """Creates and sets up the environment."""
   env = load_environment(gin_config_file)
-  env._metrics_path = metrics_path
+  env.metrics_path = metrics_path
   env._occupancy_normalization_constant = occupancy_normalization_constant
 
   return env

--- a/smart_control/reinforcement_learning/utils/environment.py
+++ b/smart_control/reinforcement_learning/utils/environment.py
@@ -25,6 +25,6 @@ def create_and_setup_environment(
   """Creates and sets up the environment."""
   env = load_environment(gin_config_file)
   env.metrics_path = metrics_path
-  env._occupancy_normalization_constant = occupancy_normalization_constant
+  env.occupancy_normalization_constant = occupancy_normalization_constant
 
   return env

--- a/smart_control/simulator/building.py
+++ b/smart_control/simulator/building.py
@@ -697,12 +697,12 @@ class FloorPlanBasedBuilding(BaseSimulatorBuilding):
       )
 
     elif floor_plan is None and floor_plan_filepath:
-      self._floor_plan = building_utils.read_floor_plan_from_filepath(
+      self.floor_plan = building_utils.read_floor_plan_from_filepath(
           floor_plan_filepath
       )
 
     elif floor_plan is not None and floor_plan_filepath is None:
-      self._floor_plan = floor_plan
+      self.floor_plan = floor_plan
 
     else:
       raise ValueError("floor_plan and floor_plan_filepath ")
@@ -724,7 +724,7 @@ class FloorPlanBasedBuilding(BaseSimulatorBuilding):
 
     (self._room_dict, exterior_walls, interior_walls, self._exterior_space) = (
         building_utils.construct_building_data_types(
-            floor_plan=self._floor_plan, zone_map=zone_map
+            floor_plan=self.floor_plan, zone_map=zone_map
         )
     )
 

--- a/smart_control/simulator/building_test.py
+++ b/smart_control/simulator/building_test.py
@@ -521,7 +521,7 @@ class BuildingTest(parameterized.TestCase):
     )
 
     with self.subTest("floor_plans"):
-      np.testing.assert_array_equal(b._floor_plan, floor_plan)
+      np.testing.assert_array_equal(b.floor_plan, floor_plan)
     with self.subTest("exterior_wall"):
       np.testing.assert_array_equal(b._exterior_walls, expected_exterior_walls)
     with self.subTest("interior_wall"):

--- a/smart_control/simulator/simulator.py
+++ b/smart_control/simulator/simulator.py
@@ -70,7 +70,7 @@ class Simulator:
         be logged.
       start_timestamp: Pandas timestamp representing start time for simulation.
     """
-    self._building = building
+    self.building = building
     self._hvac = hvac
     self._weather_controller = weather_controller
     self._time_step_sec = time_step_sec
@@ -82,7 +82,7 @@ class Simulator:
 
   def reset(self):
     """Resets the simulation to its initial configuration."""
-    self._building.reset()
+    self.building.reset()
     self._hvac.reset()
     self._current_timestamp = self._start_timestamp
 
@@ -118,13 +118,13 @@ class Simulator:
       convection_coefficient: Current wind convection coefficient (W/m2/K).
     """
     x, y = cv_coordinates
-    delta_x = self._building.cv_size_cm / 100.0
+    delta_x = self.building.cv_size_cm / 100.0
     delta_t = self._time_step_sec
-    density = self._building.density[x][y]
-    conductivity = self._building.conductivity[x][y]
-    heat_capacity = self._building.heat_capacity[x][y]
-    last_temp = self._building.temp[x][y]
-    neighbors = self._building.neighbors[x][y]
+    density = self.building.density[x][y]
+    conductivity = self.building.conductivity[x][y]
+    heat_capacity = self.building.heat_capacity[x][y]
+    last_temp = self.building.temp[x][y]
+    neighbors = self.building.neighbors[x][y]
     neighbor_temps = [temperature_estimates[nx][ny] for nx, ny in neighbors]
 
     # Ensure corner CV.
@@ -164,13 +164,13 @@ class Simulator:
       convection_coefficient: Current wind convection coefficient (W/m2/K).
     """
     x, y = cv_coordinates
-    delta_x = self._building.cv_size_cm / 100.0
+    delta_x = self.building.cv_size_cm / 100.0
     delta_t = self._time_step_sec
-    density = self._building.density[x][y]
-    conductivity = self._building.conductivity[x][y]
-    heat_capacity = self._building.heat_capacity[x][y]
-    last_temp = self._building.temp[x][y]
-    neighbors = self._building.neighbors[x][y]
+    density = self.building.density[x][y]
+    conductivity = self.building.conductivity[x][y]
+    heat_capacity = self.building.heat_capacity[x][y]
+    last_temp = self.building.temp[x][y]
+    neighbors = self.building.neighbors[x][y]
     neighbor_temps = [temperature_estimates[nx][ny] for nx, ny in neighbors]
 
     # Ensure edge CV.
@@ -181,7 +181,7 @@ class Simulator:
 
     # Edges and corners are multiplied by 0.5, others by 1.0
     edge_factor = [
-        0.5 if len(self._building.neighbors[nx][ny]) < 4 else 1.0
+        0.5 if len(self.building.neighbors[nx][ny]) < 4 else 1.0
         for nx, ny in neighbors
     ]
 
@@ -211,15 +211,15 @@ class Simulator:
       temperature_estimates: Current temperature estimate for each CV.
     """
     x, y = cv_coordinates
-    delta_x = self._building.cv_size_cm / 100.0
+    delta_x = self.building.cv_size_cm / 100.0
     delta_t = self._time_step_sec
-    z = self._building.floor_height_cm / 100.0
-    density = self._building.density[x][y]
-    conductivity = self._building.conductivity[x][y]
-    heat_capacity = self._building.heat_capacity[x][y]
-    last_temp = self._building.temp[x][y]
-    input_q = self._building.input_q[x][y]
-    neighbors = self._building.neighbors[x][y]
+    z = self.building.floor_height_cm / 100.0
+    density = self.building.density[x][y]
+    conductivity = self.building.conductivity[x][y]
+    heat_capacity = self.building.heat_capacity[x][y]
+    last_temp = self.building.temp[x][y]
+    input_q = self.building.input_q[x][y]
+    neighbors = self.building.neighbors[x][y]
     neighbor_temps = [temperature_estimates[nx][ny] for nx, ny in neighbors]
 
     # Ensure interior CV.
@@ -255,7 +255,7 @@ class Simulator:
       convection_coefficient: Current wind convection coefficient (W/m2/K).
     """
     x, y = cv_coordinates
-    neighbors = self._building.neighbors[x][y]
+    neighbors = self.building.neighbors[x][y]
     if len(neighbors) <= 1:
       # Exterior CVs should always return ambient air temps.
       return ambient_temperature
@@ -345,7 +345,7 @@ class Simulator:
     """
     # Initialize estimates with the last update.
     # TODO(gusatb): Please provide a unit test for convergence.
-    temp_estimate = self._building.temp.copy()
+    temp_estimate = self.building.temp.copy()
 
     converged_successfully = False
     for iteration_count in range(self._iteration_limit):
@@ -369,7 +369,7 @@ class Simulator:
       logging.warning(
           'Max iteration count reached, max_delta = %3.3f', max_delta
       )
-    self._building.temp = temp_estimate
+    self.building.temp = temp_estimate
 
     return converged_successfully
 
@@ -390,7 +390,7 @@ class Simulator:
 
     # Get the average temps in each zone. Assumes that the thermostat reads
     # the average room temperatures.
-    avg_temps = self._building.get_zone_average_temps()
+    avg_temps = self.building.get_zone_average_temps()
 
     for zone, zone_temp in avg_temps.items():
       vav = hvac.vavs[zone]
@@ -405,10 +405,10 @@ class Simulator:
 
     # Get the average temps in each zone. Assumes that the thermostat reads
     # the average room temperatures.
-    avg_temps = self._building.get_zone_average_temps()
+    avg_temps = self.building.get_zone_average_temps()
 
     # Recirculation temperature at the air handler is the global average.
-    recirculation_temp = self._building.temp.mean()
+    recirculation_temp = self.building.temp.mean()
 
     ambient_temperature = self._weather_controller.get_current_temp(current_ts)
 
@@ -448,7 +448,7 @@ class Simulator:
         hvac.boiler.add_demand(vav.reheat_demand)
 
       # Apply the thermal energy to the zone.
-      self._building.apply_thermal_power_zone(zone, q_zone)
+      self.building.apply_thermal_power_zone(zone, q_zone)
 
     hvac.boiler.return_water_temperature_sensor = (
         self._calculate_return_water_temperature(zone_supply_temp_map)
@@ -497,7 +497,7 @@ class Simulator:
     for (
         zone_coords,
         zone_air_temperature,
-    ) in self._building.get_zone_average_temps().items():
+    ) in self.building.get_zone_average_temps().items():
       zone_id = conversion_utils.zone_coordinates_to_id(zone_coords)
       zone_reward_infos[zone_id] = self._get_zone_reward_info(
           occupancy_function, zone_coords, zone_id, zone_air_temperature
@@ -517,7 +517,7 @@ class Simulator:
         self._hvac.air_handler.compute_intake_fan_energy_rate()
         + self._hvac.air_handler.compute_exhaust_fan_energy_rate()
     )
-    recirculation_temp = self._building.temp.mean()
+    recirculation_temp = self.building.temp.mean()
     ambient_temp = self._weather_controller.get_current_temp(
         self._current_timestamp
     )

--- a/smart_control/simulator/simulator_building.py
+++ b/smart_control/simulator/simulator_building.py
@@ -63,10 +63,10 @@ class SimulatorBuilding(BaseBuilding):
       occupancy: a function to determine building occupancy by zone.
     """
 
-    self._simulator = simulator
+    self.simulator = simulator
 
     self._occupancy = occupancy
-    hvac = self._simulator.hvac
+    hvac = self.simulator.hvac
 
     # List of tuple (device, device_info)
     all_devices = [
@@ -136,7 +136,7 @@ class SimulatorBuilding(BaseBuilding):
   @property
   def reward_info(self) -> smart_control_reward_pb2.RewardInfo:
     """Returns a message with data to compute the instantaneous reward."""
-    return self._simulator.reward_info(self._occupancy)
+    return self.simulator.reward_info(self._occupancy)
 
   def request_observations_within_time_interval(
       self,
@@ -155,7 +155,7 @@ class SimulatorBuilding(BaseBuilding):
     observation_response.request.CopyFrom(observation_request)
     observation_response.timestamp.CopyFrom(
         conversion_utils.pandas_to_proto_timestamp(
-            self._simulator.current_timestamp
+            self.simulator.current_timestamp
         )
     )
     for single_request in observation_request.single_observation_requests:
@@ -164,7 +164,7 @@ class SimulatorBuilding(BaseBuilding):
       single_response.single_observation_request.CopyFrom(single_request)
       single_response.timestamp.CopyFrom(
           conversion_utils.pandas_to_proto_timestamp(
-              self._simulator.current_timestamp
+              self.simulator.current_timestamp
           )
       )
       single_response.observation_valid = True
@@ -183,7 +183,7 @@ class SimulatorBuilding(BaseBuilding):
       device = self._device_map[single_request.device_id]
       try:
         observed_value = device.get_observation(
-            single_request.measurement_name, self._simulator.current_timestamp
+            single_request.measurement_name, self.simulator.current_timestamp
         )
         # TODO(gusatb): Extend this to handle non-continuous types.
         single_response.continuous_value = observed_value
@@ -205,13 +205,13 @@ class SimulatorBuilding(BaseBuilding):
   ) -> smart_control_building_pb2.ActionResponse:
     """Issues a command to the building to change one or more setpoints."""
     # Set up default building behavior
-    self._simulator.setup_step_sim()
+    self.simulator.setup_step_sim()
 
     action_response = smart_control_building_pb2.ActionResponse()
     action_response.request.CopyFrom(action_request)
     action_response.timestamp.CopyFrom(
         conversion_utils.pandas_to_proto_timestamp(
-            self._simulator.current_timestamp
+            self.simulator.current_timestamp
         )
     )
     for single_request in action_request.single_action_requests:
@@ -244,7 +244,7 @@ class SimulatorBuilding(BaseBuilding):
         device.set_action(
             single_request.setpoint_name,
             set_value,
-            self._simulator.current_timestamp,
+            self.simulator.current_timestamp,
         )
       except (AttributeError, ValueError) as e:
         single_response.response_type = (
@@ -264,11 +264,11 @@ class SimulatorBuilding(BaseBuilding):
   def wait_time(self) -> None:
     """Returns after a certain amount of time."""
     # Update the building state.
-    self._simulator.execute_step_sim()
+    self.simulator.execute_step_sim()
 
   def reset(self) -> None:
     """Resets the building, throwing a RuntimeError if this is impossible."""
-    self._simulator.reset()
+    self.simulator.reset()
 
   @property
   def devices(self) -> Sequence[smart_control_building_pb2.DeviceInfo]:
@@ -279,17 +279,17 @@ class SimulatorBuilding(BaseBuilding):
   def zones(self) -> Sequence[smart_control_building_pb2.ZoneInfo]:
     """Lists the zones in the building managed by the RL agent."""
 
-    return list(self._simulator.hvac.zone_infos.values())
+    return list(self.simulator.hvac.zone_infos.values())
 
   @property
   def time_step_sec(self) -> float:
     """Returns the amount of time between time steps."""
-    return self._simulator.time_step_sec
+    return self.simulator.time_step_sec
 
   @property
   def current_timestamp(self) -> pd.Timestamp:
     """Lists the current local time of the building."""
-    return self._simulator.current_timestamp
+    return self.simulator.current_timestamp
 
   def render(self, path: str) -> None:
     """Renders the current state of the building."""
@@ -299,7 +299,7 @@ class SimulatorBuilding(BaseBuilding):
 
   def is_comfort_mode(self, current_time: pd.Timestamp) -> bool:
     """Returns True if building is in comfort mode."""
-    return self._simulator.hvac.is_comfort_mode(current_time)
+    return self.simulator.hvac.is_comfort_mode(current_time)
 
   @property
   def num_occupants(self) -> int:

--- a/smart_control/simulator/simulator_flexible_floor_plan.py
+++ b/smart_control/simulator/simulator_flexible_floor_plan.py
@@ -77,17 +77,17 @@ class SimulatorFlexibleGeometries(simulator.Simulator):
         be logged.
       start_timestamp: Pandas timestamp representing start time for simulation.
     """
-    self._building = building
+    self.building = building
     self._hvac = hvac
 
     logging.info("Constructing the floorplan based simulation.")
 
     if self._hvac.fill_zone_identifier_exogenously:
       logging.info("Filling zones exogenously")
-      self._hvac.initialize_zone_identifier(self._building._room_dict.keys())
+      self._hvac.initialize_zone_identifier(self.building._room_dict.keys())
 
     super().__init__(
-        self._building,
+        self.building,
         self._hvac,
         weather_controller,
         time_step_sec,
@@ -99,7 +99,7 @@ class SimulatorFlexibleGeometries(simulator.Simulator):
 
     logging.info("Constructing the floorplan based simulation.")
 
-    render_zones = np.copy(self._building.floor_plan)
+    render_zones = np.copy(self.building.floor_plan)
     render_zones[render_zones == 2] = 0
 
     renderer = building_renderer.BuildingRenderer(render_zones, 1)
@@ -109,7 +109,7 @@ class SimulatorFlexibleGeometries(simulator.Simulator):
 
   def reset(self):
     """Resets the simulation to its initial configuration."""
-    self._building.reset()
+    self.building.reset()
     self._hvac.reset()
     self._current_timestamp = self._start_timestamp
 
@@ -135,10 +135,10 @@ class SimulatorFlexibleGeometries(simulator.Simulator):
 
     # Get the average temps in each zone. Assumes that the thermostat reads
     # the average room temperatures.
-    avg_temps = self._building.get_zone_average_temps()
+    avg_temps = self.building.get_zone_average_temps()
 
     # Recirculation temperature at the air handler is the global average.
-    recirculation_temp = self._building.temp.mean()
+    recirculation_temp = self.building.temp.mean()
 
     ambient_temperature = self._weather_controller.get_current_temp(current_ts)
 
@@ -157,7 +157,7 @@ class SimulatorFlexibleGeometries(simulator.Simulator):
     )
 
     # Simulate airflow
-    self._building.apply_convection()
+    self.building.apply_convection()
 
     # Reset the air handler and boiler flow rate demand before accumulating.
     hvac.air_handler.reset_demand()
@@ -180,7 +180,7 @@ class SimulatorFlexibleGeometries(simulator.Simulator):
         hvac.boiler.add_demand(vav.reheat_demand)
 
       # Apply the thermal energy to the zone.
-      self._building.apply_thermal_power_zone(zone, q_zone)
+      self.building.apply_thermal_power_zone(zone, q_zone)
 
     hvac.boiler.return_water_temperature_sensor = (
         self._calculate_return_water_temperature(zone_supply_temp_map)
@@ -188,7 +188,7 @@ class SimulatorFlexibleGeometries(simulator.Simulator):
 
     # Increment the timestamp.
     self._current_timestamp += pd.Timedelta(self._time_step_sec, unit="s")
-    self._log_and_plotter.log(self._building.temp)
+    self._log_and_plotter.log(self.building.temp)
 
     if self.current_timestamp == self._start_timestamp + pd.Timedelta(days=4):
       self.get_video(path=constants.VIDEO_PATH_ROOT + video_filename)
@@ -233,7 +233,7 @@ class SimulatorFlexibleGeometries(simulator.Simulator):
     for (
         zone_coords,
         zone_air_temperature,
-    ) in self._building.get_zone_average_temps().items():
+    ) in self.building.get_zone_average_temps().items():
       zone_id = conversion_utils.floor_plan_based_zone_identifier_to_id(
           zone_coords
       )
@@ -255,7 +255,7 @@ class SimulatorFlexibleGeometries(simulator.Simulator):
         self._hvac.air_handler.compute_intake_fan_energy_rate()
         + self._hvac.air_handler.compute_exhaust_fan_energy_rate()
     )
-    recirculation_temp = self._building.temp.mean()
+    recirculation_temp = self.building.temp.mean()
     ambient_temp = self._weather_controller.get_current_temp(
         self._current_timestamp
     )

--- a/smart_control/simulator/simulator_flexible_floor_plan.py
+++ b/smart_control/simulator/simulator_flexible_floor_plan.py
@@ -99,7 +99,7 @@ class SimulatorFlexibleGeometries(simulator.Simulator):
 
     logging.info("Constructing the floorplan based simulation.")
 
-    render_zones = np.copy(self._building._floor_plan)
+    render_zones = np.copy(self._building.floor_plan)
     render_zones[render_zones == 2] = 0
 
     renderer = building_renderer.BuildingRenderer(render_zones, 1)

--- a/smart_control/simulator/simulator_flexible_floor_plan_test.py
+++ b/smart_control/simulator/simulator_flexible_floor_plan_test.py
@@ -495,7 +495,7 @@ class FlexibleFloorplanSimulatorTest(parameterized.TestCase):
         start_timestamp,
     )
 
-    self.assertEqual(simulator._building, building)
+    self.assertEqual(simulator.building, building)
     self.assertEqual(simulator._weather_controller, weather_controller)
     self.assertEqual(simulator._time_step_sec, time_step_sec)
     self.assertEqual(simulator.time_step_sec, time_step_sec)
@@ -528,10 +528,10 @@ class FlexibleFloorplanSimulatorTest(parameterized.TestCase):
         start_timestamp,
     )
 
-    simulator._building.temp[2][2] += 10.0
-    simulator._building.temp[0][3] += 10.0
-    simulator._building.input_q[2][2] = 1000.0
-    simulator._building.input_q[0][3] = 1000.0
+    simulator.building.temp[2][2] += 10.0
+    simulator.building.temp[0][3] += 10.0
+    simulator.building.input_q[2][2] = 1000.0
+    simulator.building.input_q[0][3] = 1000.0
 
     simulator.hvac.boiler._return_water_temperature_sensor += 10.0
     simulator.hvac.boiler._water_pump_differential_head += 100.0
@@ -549,7 +549,7 @@ class FlexibleFloorplanSimulatorTest(parameterized.TestCase):
 
     simulator._current_timestamp += pd.Timedelta(360.0, unit="seconds")
     simulator.reset()
-    self.assertEqual(simulator._building, building)
+    self.assertEqual(simulator.building, building)
     expected_hvac = self._create_small_hvac()
     expected_air_handler = expected_hvac.air_handler
     self.assertEqual(
@@ -589,10 +589,10 @@ class FlexibleFloorplanSimulatorTest(parameterized.TestCase):
     self.assertEqual(simulator._hvac.boiler._total_flow_rate, 0)
 
     self.assertEqual(simulator._current_timestamp, start_timestamp)
-    self.assertEqual(simulator._building.temp[2][2], initial_temp)
-    self.assertEqual(simulator._building.temp[0][3], initial_temp)
-    self.assertEqual(simulator._building.input_q[2][2], 0)
-    self.assertEqual(simulator._building.input_q[0][3], 0)
+    self.assertEqual(simulator.building.temp[2][2], initial_temp)
+    self.assertEqual(simulator.building.temp[0][3], initial_temp)
+    self.assertEqual(simulator.building.input_q[2][2], 0)
+    self.assertEqual(simulator.building.input_q[0][3], 0)
 
   def test_get_cv_temp_estimate_cell_no_change(self):
     """This tests that temperatures don"t change in stable conditions.
@@ -1384,7 +1384,7 @@ class FlexibleFloorplanSimulatorTest(parameterized.TestCase):
           .thermostat.get_setpoint_schedule()
           .get_temperature_window(sim._current_timestamp)
       )
-      zone_temperature = sim._building.get_zone_average_temps()[coords]
+      zone_temperature = sim.building.get_zone_average_temps()[coords]
 
       expected_zone_info = smart_control_reward_pb2.RewardInfo.ZoneRewardInfo(
           heating_setpoint_temperature=heating_setpoint,
@@ -1412,7 +1412,7 @@ class FlexibleFloorplanSimulatorTest(parameterized.TestCase):
         air_handler_reward_info.blower_electrical_energy_rate,
     )
 
-    recirculation_temp = sim._building.temp.mean()
+    recirculation_temp = sim.building.temp.mean()
     ambient_temp = sim._weather_controller.get_current_temp(
         sim._current_timestamp
     )

--- a/smart_control/simulator/simulator_test.py
+++ b/smart_control/simulator/simulator_test.py
@@ -237,7 +237,7 @@ class SimulatorTest(parameterized.TestCase):
         start_timestamp,
     )
 
-    self.assertEqual(simulator._building, building)
+    self.assertEqual(simulator.building, building)
     self.assertEqual(simulator._weather_controller, weather_controller)
     self.assertEqual(simulator._time_step_sec, time_step_sec)
     self.assertEqual(simulator.time_step_sec, time_step_sec)
@@ -270,10 +270,10 @@ class SimulatorTest(parameterized.TestCase):
         start_timestamp,
     )
 
-    simulator._building.temp[2][2] += 10.0
-    simulator._building.temp[0][3] += 10.0
-    simulator._building.input_q[2][2] = 1000.0
-    simulator._building.input_q[0][3] = 1000.0
+    simulator.building.temp[2][2] += 10.0
+    simulator.building.temp[0][3] += 10.0
+    simulator.building.input_q[2][2] = 1000.0
+    simulator.building.input_q[0][3] = 1000.0
 
     simulator.hvac.boiler._return_water_temperature_sensor += 10.0
     simulator.hvac.boiler._water_pump_differential_head += 100.0
@@ -291,7 +291,7 @@ class SimulatorTest(parameterized.TestCase):
 
     simulator._current_timestamp += pd.Timedelta(360.0, unit='seconds')
     simulator.reset()
-    self.assertEqual(simulator._building, building)
+    self.assertEqual(simulator.building, building)
     expected_hvac = self._create_small_hvac()
     expected_air_handler = expected_hvac.air_handler
     self.assertEqual(
@@ -331,10 +331,10 @@ class SimulatorTest(parameterized.TestCase):
     self.assertEqual(simulator._hvac.boiler._total_flow_rate, 0)
 
     self.assertEqual(simulator._current_timestamp, start_timestamp)
-    self.assertEqual(simulator._building.temp[2][2], initial_temp)
-    self.assertEqual(simulator._building.temp[0][3], initial_temp)
-    self.assertEqual(simulator._building.input_q[2][2], 0)
-    self.assertEqual(simulator._building.input_q[0][3], 0)
+    self.assertEqual(simulator.building.temp[2][2], initial_temp)
+    self.assertEqual(simulator.building.temp[0][3], initial_temp)
+    self.assertEqual(simulator.building.input_q[2][2], 0)
+    self.assertEqual(simulator.building.input_q[0][3], 0)
 
   def test_get_cv_temp_estimate_cell_no_change(self):
     """This tests that temperatures don't change in stable conditions.
@@ -1053,7 +1053,7 @@ class SimulatorTest(parameterized.TestCase):
           .thermostat.get_setpoint_schedule()
           .get_temperature_window(sim._current_timestamp)
       )
-      zone_temperature = sim._building.get_zone_average_temps()[coords]
+      zone_temperature = sim.building.get_zone_average_temps()[coords]
 
       expected_zone_info = smart_control_reward_pb2.RewardInfo.ZoneRewardInfo(
           heating_setpoint_temperature=heating_setpoint,
@@ -1081,7 +1081,7 @@ class SimulatorTest(parameterized.TestCase):
         air_handler_reward_info.blower_electrical_energy_rate,
     )
 
-    recirculation_temp = sim._building.temp.mean()
+    recirculation_temp = sim.building.temp.mean()
     ambient_temp = sim._weather_controller.get_current_temp(
         sim._current_timestamp
     )

--- a/smart_control/simulator/tf_simulator.py
+++ b/smart_control/simulator/tf_simulator.py
@@ -541,14 +541,14 @@ class TFSimulator(simulator.SimulatorFlexibleGeometries):
     n_exterior_elements = tf.math.count_nonzero(self._t_exerior_temps_mask)
     logging.info('Number of exterior CVs: %d', n_exterior_elements)
 
-    n_elements = self._building.temp.shape[0] * self._building.temp.shape[1]
+    n_elements = self.building.temp.shape[0] * self.building.temp.shape[1]
     n_interior_elements = n_elements - n_boundary_elements - n_exterior_elements
     logging.info('Number of interior CVs: %d', n_interior_elements)
 
     self._t_u, self._t_v = get_cv_dimension_tensors(
-        self._building.cv_size_cm / 100.0,
+        self.building.cv_size_cm / 100.0,
         self._boundary_cv_mapping,
-        self._building.temp.shape,
+        self.building.temp.shape,
     )
 
     (
@@ -557,7 +557,7 @@ class TFSimulator(simulator.SimulatorFlexibleGeometries):
         self._t_conductivity_top_edge,
         self._t_conductivity_bottom_edge,
     ) = get_oriented_conductivity_tensors(
-        self._building.conductivity, self._boundary_cv_mapping
+        self.building.conductivity, self._boundary_cv_mapping
     )
 
   def _get_tensor_exterior_mask(
@@ -765,7 +765,7 @@ class TFSimulator(simulator.SimulatorFlexibleGeometries):
         t_density,
         t_heat_capacity,
         t_z,
-    ) = _get_input_tensors(self._building)
+    ) = _get_input_tensors(self.building)
 
     (
         t_convection_left_edge,
@@ -774,7 +774,7 @@ class TFSimulator(simulator.SimulatorFlexibleGeometries):
         t_convection_bottom_edge,
     ) = get_oriented_convection_coefficient_tensors(
         convection_coefficient,
-        self._building.temp.shape,
+        self.building.temp.shape,
         self._boundary_cv_mapping,
     )
 


### PR DESCRIPTION
Update files to make pre-submit checks pass, so we can merge the code into Google.

Addresses Protected Access -related linting checks: 

  + protected-access (W0212)


Notes:

  + Most of the failing "protected-access" errors are occurring in test files that are testing the protected methods. The [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html#3162-naming-conventions) says "it is okay for unit tests to access protected constants from the modules under test". Interpreting / extending this rule to apply to protected methods and properties, we are ignoring all "protected-access" errors in test files. Pylint doesn't support this capability natively, so we are using a package called `pylint-per-file-ignores` to achieve this. Side note: after figuring out how to get this package configured properly, we submitted a [PR](https://github.com/christopherpickering/pylint-per-file-ignores/pull/192) back to that package to update its documentation to include a working regex example  we are using to match all test files that end in "_test.py".
  + For the remaining "protected-access" errors occurring outside of test files, we chose to fix them instead of ignoring them. When converting the protected members to public, we checked the inheritance chain to ensure the protected methods didn't exist in parent classes, and updated the methods in child classes as applicable.

Commands run during setup:

```sh
poetry add pylint-per-file-ignores --group dev
```

Additional details about protected to public conversions:

  + When loading the environment in "smart_control/reinforcement_learning/utils/environment.py", we were setting protected members `_metrics_path` and `_occupancy_normalization_constant`. To fix, we made those properties public access in the `Environment` class. 
  + When creating the baseline schedule policy in "smart_control/reinforcement_learning/policies/schedule_policy.py", we were accessing protected members `_field_names` and `_action_normalizers`. To fix, we made those properties public in the `Environment` class, and made the `_action_normalizers` property public in the related `ActionConfig` class. 
  + When rendering the environment in "smart_control/reinforcement_learning/observers/rendering_observer.py", we were accessing protected members `_floor_plan`, `_simulator` and `_building`. Also when initializing the flexible geometries simulator in "smart_control/simulator/simulator_flexible_floor_plan.py" we were accessing the protected `_floor_plan`. To fix, we made public: 
    + the `_simulator` property in the `SimulatorBuilding` class 
    + the `_building` property in the `Simulator` class, as well as in the `SimulatorFlexibleGeometries` and `TFSimulator` child classes 
    + the `_floor_plan` property in the `FloorPlanBasedBuilding` class


