### PR TITLE
Pre-submit Checks: Imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,12 @@ To check for a specific issue (e.g. "missing-module-docstring"), using the corre
 
 ```sh
 pylint smart_control --rcfile=.pylintrc --ignore=proto --disable=all --enable=C0114
+
+# using Google internal tools to check for Google-specific errors:
+#gpylint smart_control --ignore=proto --disable=all --enable=C6202
 ```
 
-> NOTE: some error messages beginning with "g-" are additional Google-specific errors that may need to be checked using internal tools (`gpylint`), and may not be able to be checked by open source contributors at this time.
+> NOTE: some error messages beginning with "g-" are additional Google-specific errors that may need to be checked using internal tools (`gpylint`), and may not be able to be checked by open source contributors at this time. Maintainer note: `gpylint` may not work with the ".pylintrc" config file.
 
 If you would like to prevent certain lines of code from being checked (for example to leave a long line as-is), it is possible to [ignore formatting](hhttps://pylint.readthedocs.io/en/stable/user_guide/messages/message_control.html#block-disables) by adding `pylint` pragma comments like `# pylint: disable=line-too-long`. NOTE: `pylint` and `pyink` (see section above) may each require their own set of separate pragma comments.
 

--- a/README.md
+++ b/README.md
@@ -139,10 +139,10 @@ If you would like to run the style checker manually:
 
 ```sh
 # check all files:
-pylint --rcfile=.pylintrc smart_control
+pylint --rcfile=.pylintrc --ignore=proto smart_control
 
 # check a specific file:
-pylint --rcfile=.pylintrc smart_control/path/to/file.py
+pylint --rcfile=.pylintrc --ignore=proto smart_control/path/to/file.py
 ```
 
 To check for a specific issue (e.g. "missing-module-docstring"), using the corresponding [message code](https://pylint.readthedocs.io/en/stable/user_guide/messages/messages_overview.html) (e.g. "C0114"):

--- a/smart_control/reinforcement_learning/policies/schedule_policy.py
+++ b/smart_control/reinforcement_learning/policies/schedule_policy.py
@@ -1,6 +1,6 @@
 """Reinforcement learning schedule policies."""
 
-from dataclasses import dataclass
+import dataclasses
 import enum
 import logging
 from typing import Dict, List, Optional, Tuple, Union
@@ -33,7 +33,7 @@ SetpointValue = Union[float, int, bool]
 ActionSequence = List[Tuple[DeviceType, SetpointName]]
 
 
-@dataclass
+@dataclass.dataclass
 class ScheduleEvent:
   """An event that sets a specific value at a specific time."""
 

--- a/smart_control/reinforcement_learning/policies/schedule_policy.py
+++ b/smart_control/reinforcement_learning/policies/schedule_policy.py
@@ -33,7 +33,7 @@ SetpointValue = Union[float, int, bool]
 ActionSequence = List[Tuple[DeviceType, SetpointName]]
 
 
-@dataclass.dataclass
+@dataclasses.dataclass
 class ScheduleEvent:
   """An event that sets a specific value at a specific time."""
 

--- a/smart_control/reinforcement_learning/scripts/populate_starter_buffer.py
+++ b/smart_control/reinforcement_learning/scripts/populate_starter_buffer.py
@@ -4,6 +4,7 @@ This creates a starter buffer with exploration data that can be used to
 bootstrap the training process.
 """
 
+import argparse
 import logging
 import os
 
@@ -18,6 +19,7 @@ from smart_control.reinforcement_learning.observers.composite_observer import Co
 from smart_control.reinforcement_learning.observers.print_status_observer import PrintStatusObserver
 from smart_control.reinforcement_learning.policies.schedule_policy import create_baseline_schedule_policy
 from smart_control.reinforcement_learning.replay_buffer.replay_buffer import ReplayBufferManager
+from smart_control.reinforcement_learning.utils.config import CONFIG_PATH
 from smart_control.reinforcement_learning.utils.config import OUTPUT_DATA_PATH
 from smart_control.reinforcement_learning.utils.environment import create_and_setup_environment
 
@@ -181,9 +183,6 @@ def populate_replay_buffer(
 
 
 if __name__ == '__main__':
-  import argparse
-
-  from smart_control.reinforcement_learning.utils.config import CONFIG_PATH
 
   config_filepath = os.path.join(CONFIG_PATH, 'sim_config_1_day.gin')
 

--- a/smart_control/reinforcement_learning/scripts/train.py
+++ b/smart_control/reinforcement_learning/scripts/train.py
@@ -10,7 +10,7 @@ import os
 # https://github.com/tensorflow/tensorflow/issues/63548#issuecomment-2008941537
 os.environ['WRAPT_DISABLE_EXTENSIONS'] = 'true'
 
-from datetime import datetime
+import datetime
 import logging
 
 import tensorflow as tf
@@ -77,7 +77,7 @@ def train_agent(
   scenario_config_path = os.path.join(CONFIG_PATH, 'sim_config_1_day.gin')
 
   # Generate timestamp for summary directory
-  current_time = datetime.now().strftime('%Y_%m_%d-%H:%M:%S')
+  current_time = datetime.datetime.now().strftime('%Y_%m_%d-%H:%M:%S')
   summary_dir = os.path.join(
       EXPERIMENT_RESULTS_PATH, f'{experiment_name}_{current_time}'
   )

--- a/smart_control/reinforcement_learning/scripts/train.py
+++ b/smart_control/reinforcement_learning/scripts/train.py
@@ -10,6 +10,8 @@ import os
 # https://github.com/tensorflow/tensorflow/issues/63548#issuecomment-2008941537
 os.environ['WRAPT_DISABLE_EXTENSIONS'] = 'true'
 
+# pylint: disable=g-import-not-at-top
+import argparse
 import datetime
 import logging
 
@@ -30,6 +32,8 @@ from smart_control.reinforcement_learning.replay_buffer.replay_buffer import Rep
 from smart_control.reinforcement_learning.utils.config import CONFIG_PATH
 from smart_control.reinforcement_learning.utils.config import EXPERIMENT_RESULTS_PATH
 from smart_control.reinforcement_learning.utils.environment import create_and_setup_environment
+
+# pylint: enable=g-import-not-at-top
 
 # Configure logging
 logging.basicConfig(
@@ -300,7 +304,6 @@ def train_agent(
 
 
 if __name__ == '__main__':
-  import argparse
 
   parser = argparse.ArgumentParser(
       description=(

--- a/smart_control/utils/building_image_generator.py
+++ b/smart_control/utils/building_image_generator.py
@@ -34,9 +34,9 @@ from smart_control.utils import building_renderer
 from smart_control.utils import real_building_temperature_array_generator as temp_array_gen
 
 if sys.version_info >= (3, 11):
-  from importlib.resources.abc import Traversable  # pylint: disable=g-import-not-at-top
+  from importlib.resources.abc import Traversable  # pylint: disable=g-import-not-at-top, g-importing-member
 else:
-  from importlib_resources.abc import Traversable  # pylint: disable=g-import-not-at-top
+  from importlib_resources.abc import Traversable  # pylint: disable=g-import-not-at-top, g-importing-member
 
 PathLocation: TypeAlias = Traversable | os.PathLike[str] | str
 

--- a/smart_control/utils/writer_lib.py
+++ b/smart_control/utils/writer_lib.py
@@ -27,9 +27,9 @@ from smart_control.proto import smart_control_normalization_pb2
 from smart_control.proto import smart_control_reward_pb2
 
 if sys.version_info >= (3, 11):
-  from importlib.resources.abc import Traversable  # pylint: disable=g-import-not-at-top
+  from importlib.resources.abc import Traversable  # pylint: disable=g-import-not-at-top, g-importing-member
 else:
-  from importlib_resources.abc import Traversable  # pylint: disable=g-import-not-at-top
+  from importlib_resources.abc import Traversable  # pylint: disable=g-import-not-at-top, g-importing-member
 
 PathLocation: TypeAlias = Traversable | os.PathLike[str] | str
 


### PR DESCRIPTION
Update files to make pre-submit checks pass, so we can merge the code into Google.

Addresses Import -related linting checks: 

  + g-importing-member (C6202)
  + g-bad-import-order (C6203) -- NOT ADDRESSED
  + g-import-not-at-top (C6204)

NOTE:

  + We are seeing lots of "g-bad-import-order" errors that want us to group the first-party `smart_control` imports along with the packages. However we have configured `pyink` and `isort` to group these first-party imports in their own section at the bottom (desired). 
  + Currently `gpylint` doesn't recognize configuration options in the ".pylintrc" file, otherwise we would update the config file to ignore all "g-bad-import-order" errors (because `pyink` and `isort` are already handling the import sorting. 
  + We need to see if the Copybara sync process that transforms the imports to prepend `google3.` will make this "g-bad-import-order" issues go away on the Google side.
