### PR TITLE
Restore Unused References

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,6 +2,10 @@ name: Python CI Build
 
 on:
   push:
+    branches:
+      - master
+      - main
+      - copybara_push
   pull_request:
     branches:
       - master

--- a/SBSIM_OVERVIEW.md
+++ b/SBSIM_OVERVIEW.md
@@ -123,6 +123,7 @@ The `environment` module provides the reinforcement learning environment where t
 
             *   `_get_action_spec_and_normalizers(...)`: Defines the action space and normalizers based on the building devices and action configurations.
             *   `_get_observation_spec(...)`: Defines the observation space based on the building devices and observation configurations.
+            *   `_format_action(action, action_names)`: Reformat actions if necessary (extension point for subclasses).
             *   `render(mode)`: (Not implemented) Intended for rendering the environment state.
         *   **Properties**:
 

--- a/smart_control/environment/environment.py
+++ b/smart_control/environment/environment.py
@@ -1207,6 +1207,12 @@ class Environment(py_environment.PyEnvironment):
   def observation_spec(self) -> types.NestedArraySpec:
     return self._observation_spec
 
+  def _format_action(
+      self, action: types.NestedArray, action_names: Sequence[str]  # pylint: disable=unused-argument
+  ) -> types.NestedArray:
+    """Enables extension classes to reformat actions into base format."""
+    return action
+
   def _step(self, action: types.NestedArray) -> ts.TimeStep:
     """Individual time step calculations.
 

--- a/smart_control/environment/environment.py
+++ b/smart_control/environment/environment.py
@@ -1210,7 +1210,16 @@ class Environment(py_environment.PyEnvironment):
   def _format_action(
       self, action: types.NestedArray, action_names: Sequence[str]  # pylint: disable=unused-argument
   ) -> types.NestedArray:
-    """Enables extension classes to reformat actions into base format."""
+    """Enables extension classes to reformat actions into base format.
+
+    NOTE: this function is currently a no-op
+    that returns the action without formatting it.
+    However invocation of this function from within the `_step` function
+    allows child classes to format their actions.
+    So it turns out this function is required to stay here, and we are
+    allowing the unused argument.
+    See: https://github.com/google/sbsim/pull/57
+    """
     return action
 
   def _step(self, action: types.NestedArray) -> ts.TimeStep:

--- a/smart_control/environment/environment.py
+++ b/smart_control/environment/environment.py
@@ -1244,6 +1244,9 @@ class Environment(py_environment.PyEnvironment):
     reward_value = 0.0
     observation = None
 
+    # Reformat actions if necessary.
+    action = self._format_action(action, self._action_names)
+
     # Convert the action from normalized to native values.
     action_request = self._create_action_request(action)
 


### PR DESCRIPTION
Removing unused References in #32 caused Google tests to fail, so let's try to fix the tests by restoring some of the original code that was removed in that PR.

Notes:

  + It was originally thought that because the `HybridActionEnvironment` child class defines its own `_format_action` function that the definition of this function in the parent `Environment` class was unnecessary, because in the parent  class this function was a no-op that [returned the `action` without formatting it](https://github.com/google/sbsim/commit/3e7b4c4da9287da9bc1dae9c5741e1f49c67eec5#diff-cbd32a8e02d1b44ff56eba02dde2e0ca68519fb7581844c61709904a62909359L1224). 
  + However there was also an [invocation](https://github.com/google/sbsim/commit/3e7b4c4da9287da9bc1dae9c5741e1f49c67eec5#diff-cbd32a8e02d1b44ff56eba02dde2e0ca68519fb7581844c61709904a62909359L1259) of the `_format_action` function within the `_step` function of the `Environment` class, and because the `HybridActionEnvironment` class doesn't define its own `_step` function, restoring the invocation in the parent class was necessary to allow the child class to format the actions during each step. 
 + And in order for this invocation in the parent class to be valid we need to also restore the definition of the `_format_action` function within the parent class.