### PR TITLE
Pre-submit Checks: Ignore Markdown Formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- mdformat global-off -->
+
 # Google Smart Buildings Control
 
 This repository accompanies Goldfeder, J., Sipple, J., Real-World Data and Calibrated

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- mdformat off -->
+<!-- disableFinding(LINE_OVER_80) -->
 
 # Google Smart Buildings Control
 
@@ -156,7 +156,6 @@ pylint smart_control --rcfile=.pylintrc --ignore=proto --disable=all --enable=C0
 ```
 
 If you would like to prevent certain lines of code from being checked (for example to leave a long line as-is), it is possible to [ignore formatting](https://pylint.readthedocs.io/en/stable/user_guide/messages/message_control.html#block-disables) for a given message (e.g. "line-too-long") by adding a trailing comment of `# pylint: disable=line-too-long` to the right of the line / at the end of the expression, or by wrapping multiple lines of code between `# pylint: disable=line-too-long` and `# pylint: enable=line-too-long` comments.
-
 
 ### Pre-commit Hooks
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 <!-- disableFinding(LINE_OVER_80) -->
+<!-- disableFinding(WHITESPACE_LINES) -->
 
 # Google Smart Buildings Control
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- mdformat global-off -->
+<!-- mdformat off -->
 
 # Google Smart Buildings Control
 

--- a/SBSIM_OVERVIEW.md
+++ b/SBSIM_OVERVIEW.md
@@ -1,4 +1,4 @@
-<!-- mdformat global-off -->
+<!-- mdformat off -->
 
 Smart Control Project Documentation
 ===================================

--- a/SBSIM_OVERVIEW.md
+++ b/SBSIM_OVERVIEW.md
@@ -1,3 +1,5 @@
+<!-- mdformat global-off -->
+
 Smart Control Project Documentation
 ===================================
 

--- a/SBSIM_OVERVIEW.md
+++ b/SBSIM_OVERVIEW.md
@@ -1,5 +1,6 @@
 <!-- disableFinding(LINE_OVER_80) -->
 <!-- disableFinding(WHITESPACE_LINES) -->
+<!-- disableFinding(LINK_ID) -->
 
 Smart Control Project Documentation
 ===================================

--- a/SBSIM_OVERVIEW.md
+++ b/SBSIM_OVERVIEW.md
@@ -1,4 +1,4 @@
-<!-- mdformat off -->
+<!-- disableFinding(LINE_OVER_80) -->
 
 Smart Control Project Documentation
 ===================================

--- a/SBSIM_OVERVIEW.md
+++ b/SBSIM_OVERVIEW.md
@@ -1,4 +1,5 @@
 <!-- disableFinding(LINE_OVER_80) -->
+<!-- disableFinding(WHITESPACE_LINES) -->
 
 Smart Control Project Documentation
 ===================================

--- a/SBSIM_OVERVIEW.md
+++ b/SBSIM_OVERVIEW.md
@@ -1,6 +1,4 @@
-<!-- disableFinding(LINE_OVER_80) -->
-<!-- disableFinding(WHITESPACE_LINES) -->
-<!-- disableFinding(LINK_ID) -->
+<!-- linter off -->
 
 Smart Control Project Documentation
 ===================================


### PR DESCRIPTION
Ignores markdown formatting checks for "line-too-long" errors that appear in markdown files. Addresses https://github.com/google/sbsim/issues/58