### PR TITLE
Dataset Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,9 @@ __pycache__/
 # data downloads:
 sb1.zip
 sb1/
+
 data/*
+!data/.gitkeep
 data/sb1.zip
 data/sb1/
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ __pycache__/
 # data downloads:
 sb1.zip
 sb1/
+data/*
+data/sb1.zip
+data/sb1/
 
 # results files:
 */**/output_data/

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -82,6 +82,9 @@ pytest
 # disable warnings:
 pytest --disable-pytest-warnings
 
+# show print statements:
+pytest --disable-pytest-warnings -s
+
 # run specific test files:
 pytest --disable-pytest-warnings path/to/your/test.py
 

--- a/smart_control/dataset/dataset.py
+++ b/smart_control/dataset/dataset.py
@@ -1,15 +1,20 @@
 """Smart Buildings Dataset implementation, including loading and downloading."""
 
 import json
+import os
 import pickle
 import shutil
 
 import numpy as np
 import requests
 
+from smart_control.utils.constants import ROOT_DIR
+
+DATA_DIR = os.path.join(ROOT_DIR, "data")
+
 
 class SmartBuildingsDataset:
-  """Smart Buildings Dataset"""
+  """Smart Buildings Dataset."""
 
   def __init__(self, download=True):
     self.partitions = {
@@ -24,25 +29,31 @@ class SmartBuildingsDataset:
     if download:
       self.download()
 
-  def download(self):
-    """Downloads the Smart Buildings Dataset from Google Cloud Storage."""
-    print("Downloading data...")
+  @staticmethod
+  def _download_file_if_not_exists(url, timeout=60):
+    local_filename = url.split("/")[-1]
+    local_filepath = os.path.join(DATA_DIR, local_filename)
 
-    def download_file(url, timeout=200):
-      local_filename = url.split("/")[-1]
+    if not os.path.isfile(local_filepath):
 
       with requests.get(url, stream=True, timeout=timeout) as r:
         r.raise_for_status()
 
-        with open(local_filename, "wb") as f:
+        with open(local_filepath, "wb") as f:
           for chunk in r.iter_content(chunk_size=8192):
             f.write(chunk)
 
-      return local_filename
+    return local_filepath
 
+  def download(self):
+    """Downloads the Smart Buildings Dataset from Google Cloud Storage."""
+    print("Downloading data...")
     url = "https://storage.googleapis.com/gresearch/smart_buildings_dataset/tabular_data/sb1.zip"  # pylint: disable=line-too-long
-    download_file(url)
-    shutil.unpack_archive("sb1.zip", "sb1/")
+    self._download_file_if_not_exists(url)
+
+    zip_filepath = os.path.join(DATA_DIR, "sb1.zip")
+    dataset_dir = os.path.join(DATA_DIR, "sb1/")
+    shutil.unpack_archive(zip_filepath, dataset_dir)
 
   def get_floorplan(self, building):
     """Gets the floorplan and device layout map for a specific building.

--- a/smart_control/dataset/dataset.py
+++ b/smart_control/dataset/dataset.py
@@ -67,10 +67,13 @@ class SmartBuildingsDataset:
     if building not in self.partitions:
       raise ValueError("Invalid building")
 
-    floorplan = np.load(f"./{building}/tabular/floorplan.npy")
+    tabular_dirpath = os.path.join(DATA_DIR, building, "tabular")
 
-    json_filepath = f"./{building}/tabular/device_layout_map.json"
-    with open(json_filepath, encoding="utf-8") as json_file:
+    floorplan_filepath = os.path.join(tabular_dirpath, "floorplan.npy")
+    floorplan = np.load(floorplan_filepath)
+
+    device_layout_map_filepath = os.path.join(tabular_dirpath, "device_layout_map.json") # pylint:disable=line-too-long
+    with open(device_layout_map_filepath, encoding="utf-8") as json_file:
       device_layout_map = json.load(json_file)
 
     return floorplan, device_layout_map
@@ -86,22 +89,25 @@ class SmartBuildingsDataset:
       A tuple containing the data and metadata.
     """
     if building not in self.partitions:
-      raise ValueError("Invalid building")
+      raise ValueError(f"Invalid building: {building}")
 
     if partition not in self.partitions[building]:
-      raise ValueError("invalid partition")
+      raise ValueError(f"Invalid partition: {partition}.")
 
-    path = f"./{building}/tabular/{building}/{partition}/"
+    partition_dirpath = os.path.join(DATA_DIR, building, "tabular", building, partition) # pylint:disable=line-too-long
 
-    data = np.load(path + "data.npy.npz")
-    metadata = pickle.load(open(path + "metadata.pickle", "rb"))
+    data_filepath = os.path.join(partition_dirpath, "data.npy.npz")
+    data = np.load(data_filepath)
+
+    metadata_filepath = os.path.join(partition_dirpath, "metadata.pickle")
+    metadata = pickle.load(open(metadata_filepath, "rb"))
 
     if "device_infos" not in metadata.keys():
-      metadata["device_infos"] = pickle.load(
-          open(f"./{building}/tabular/device_info_dicts.pickle", "rb")
-      )
+      device_info_filepath = os.path.join(DATA_DIR, building, "tabular", "device_info_dicts.pickle") # pylint:disable=line-too-long
+      metadata["device_infos"] = pickle.load(open(device_info_filepath, "rb"))
+
     if "zone_infos" not in metadata.keys():
-      metadata["zone_infos"] = pickle.load(
-          open(f"./{building}/tabular/zone_info_dicts.pickle", "rb")
-      )
+      zone_info_filepath = os.path.join(DATA_DIR, building, "tabular", "zone_info_dicts.pickle") # pylint:disable=line-too-long
+      metadata["zone_infos"] = pickle.load(open(zone_info_filepath, "rb"))
+
     return data, metadata

--- a/smart_control/dataset/dataset.py
+++ b/smart_control/dataset/dataset.py
@@ -34,11 +34,14 @@ class SmartBuildingsDataset:
     local_filename = url.split("/")[-1]
     local_filepath = os.path.join(DATA_DIR, local_filename)
 
-    if not os.path.isfile(local_filepath):
-
+    if os.path.isfile(local_filepath):
+      print("Using previously-downloaded data...")
+      print(local_filepath)
+    else:
+      print("Downloading data...")
+      print(url)
       with requests.get(url, stream=True, timeout=timeout) as r:
         r.raise_for_status()
-
         with open(local_filepath, "wb") as f:
           for chunk in r.iter_content(chunk_size=8192):
             f.write(chunk)
@@ -47,7 +50,6 @@ class SmartBuildingsDataset:
 
   def download(self):
     """Downloads the Smart Buildings Dataset from Google Cloud Storage."""
-    print("Downloading data...")
     url = "https://storage.googleapis.com/gresearch/smart_buildings_dataset/tabular_data/sb1.zip"  # pylint: disable=line-too-long
     self._download_file_if_not_exists(url)
 
@@ -72,7 +74,7 @@ class SmartBuildingsDataset:
     floorplan_filepath = os.path.join(tabular_dirpath, "floorplan.npy")
     floorplan = np.load(floorplan_filepath)
 
-    device_layout_map_filepath = os.path.join(tabular_dirpath, "device_layout_map.json") # pylint:disable=line-too-long
+    device_layout_map_filepath = os.path.join(tabular_dirpath, "device_layout_map.json")  # pylint:disable=line-too-long
     with open(device_layout_map_filepath, encoding="utf-8") as json_file:
       device_layout_map = json.load(json_file)
 
@@ -94,7 +96,7 @@ class SmartBuildingsDataset:
     if partition not in self.partitions[building]:
       raise ValueError(f"Invalid partition: {partition}.")
 
-    partition_dirpath = os.path.join(DATA_DIR, building, "tabular", building, partition) # pylint:disable=line-too-long
+    partition_dirpath = os.path.join(DATA_DIR, building, "tabular", building, partition)  # pylint:disable=line-too-long
 
     data_filepath = os.path.join(partition_dirpath, "data.npy.npz")
     data = np.load(data_filepath)
@@ -103,11 +105,11 @@ class SmartBuildingsDataset:
     metadata = pickle.load(open(metadata_filepath, "rb"))
 
     if "device_infos" not in metadata.keys():
-      device_info_filepath = os.path.join(DATA_DIR, building, "tabular", "device_info_dicts.pickle") # pylint:disable=line-too-long
+      device_info_filepath = os.path.join(DATA_DIR, building, "tabular", "device_info_dicts.pickle")  # pylint:disable=line-too-long
       metadata["device_infos"] = pickle.load(open(device_info_filepath, "rb"))
 
     if "zone_infos" not in metadata.keys():
-      zone_info_filepath = os.path.join(DATA_DIR, building, "tabular", "zone_info_dicts.pickle") # pylint:disable=line-too-long
+      zone_info_filepath = os.path.join(DATA_DIR, building, "tabular", "zone_info_dicts.pickle")  # pylint:disable=line-too-long
       metadata["zone_infos"] = pickle.load(open(zone_info_filepath, "rb"))
 
     return data, metadata

--- a/smart_control/dataset/dataset_test.py
+++ b/smart_control/dataset/dataset_test.py
@@ -14,7 +14,8 @@ from smart_control.dataset.dataset import SmartBuildingsDataset
 
 load_dotenv()
 
-TEST_DATASET_DOWNLOAD = bool(os.getenv('TEST_DATASET_DOWNLOAD', default='false').lower() == 'true') # pylint: disable=line-too-long
+TEST_DATASET_DOWNLOAD = bool(os.getenv('TEST_DATASET_DOWNLOAD', default='false').lower() == 'true')  # pylint: disable=line-too-long
+CLEAR_DATASET_DOWNLOAD = bool(os.getenv('CLEAR_DATASET_DOWNLOAD', default='false').lower() == 'true')  # pylint: disable=line-too-long
 
 DATASET_DIRPATH = os.path.join(DATA_DIR, 'sb1')
 ZIP_FILEPATH = os.path.join(DATA_DIR, 'sb1.zip')
@@ -22,51 +23,74 @@ ZIP_FILEPATH = os.path.join(DATA_DIR, 'sb1.zip')
 SKIP_REASON = 'Skip large download by default.'
 
 
-def cleanup_files():
-  if os.path.exists(ZIP_FILEPATH):
-    os.remove(ZIP_FILEPATH)
-
-  if os.path.exists(DATASET_DIRPATH):
-    shutil.rmtree(DATASET_DIRPATH)
-
-
-class TestDataDirectory(absltest.TestCase):
-  """Tests for the data directory."""
-
-  def test_data_dir(self):
-    self.assertTrue(os.path.isdir(DATA_DIR))
-
-
 class TestDataset(absltest.TestCase):
-  """Tests for the Smart Buildings Dataset, using real downloaded data.
+  """Tests for the Smart Buildings Dataset.
 
-  It takes around two minutes to download the data, so we are skipping these
+  Includes some high fidelity tests to download the actual dataset.
+
+  It takes around two minutes to download the data, so we are skipping certain
   tests by default, to keep the build fast. But you can run them manually by
   setting the `TEST_DATASET_DOWNLOAD` environment variable to 'true'.
 
-  TODO: consider adding a mocked variation as well.
+  Downloaded data will not get cleared by default, but you can force a clean up
+  and fresh download by setting the `CLEAR_DATASET_DOWNLOAD` environment
+  variable to 'true'.
+
+  These tests are meant to be run periodically, for example once per day.
   """
 
   ds = None
 
+  @staticmethod
+  def _cleanup_files():
+    print('Deleting dataset files...')
+
+    if os.path.exists(ZIP_FILEPATH):
+      os.remove(ZIP_FILEPATH)
+
+    if os.path.exists(DATASET_DIRPATH):
+      shutil.rmtree(DATASET_DIRPATH)
+
+  def _assert_timestamps(self, timestamps, earliest, latest, length):
+    """
+    Custom assertion for standardized timestamp format.
+
+    Args:
+      timestamps (list): the timestamps to test
+      earliest and latest (str): expected earliest and latest values,
+        as strings, like '2022-06-30 00:55:00+00:00'
+      length (int) : expected length of the list
+    """
+    self.assertIsInstance(timestamps, list)
+    self.assertEqual(len(timestamps), length)
+
+    first_timestamp = timestamps[0]
+    last_timestamp = timestamps[-1]
+    self.assertIsInstance(first_timestamp, pd._libs.tslibs.timestamps.Timestamp)
+    self.assertIsInstance(last_timestamp, pd._libs.tslibs.timestamps.Timestamp)
+    self.assertEqual(str(first_timestamp), earliest)
+    self.assertEqual(str(last_timestamp), latest)
+
   @classmethod
   def setUpClass(cls):
     if TEST_DATASET_DOWNLOAD:
-      cleanup_files()
-      assert not os.path.isdir(DATASET_DIRPATH)
-      assert not os.path.exists(ZIP_FILEPATH)
-
+      if CLEAR_DATASET_DOWNLOAD:
+        cls._cleanup_files()
       cls.ds = SmartBuildingsDataset(download=True)
+    else:
+      cls.ds = SmartBuildingsDataset(download=False)
 
-      assert os.path.isdir(DATASET_DIRPATH)
-      assert os.path.exists(ZIP_FILEPATH)
+  @classmethod
+  def tearDownClass(cls):
+    if TEST_DATASET_DOWNLOAD and CLEAR_DATASET_DOWNLOAD:
+      cls._cleanup_files()
 
-  #@classmethod
-  #def tearDownClass(cls):
-  #  if TEST_DATASET_DOWNLOAD:
-  #    cleanup_files()
-  #    assert not os.path.isdir(DATASET_DIRPATH)
-  #    assert not os.path.exists(ZIP_FILEPATH)
+  def test_data_dir(self):
+    self.assertTrue(os.path.isdir(DATA_DIR))
+
+  def test_partitions(self):
+    partitions = {'sb1': ['2022_a', '2022_b', '2023_a', '2023_b', '2024_a']}
+    self.assertEqual(self.ds.partitions, partitions)
 
   @unittest.skipUnless(TEST_DATASET_DOWNLOAD, SKIP_REASON)
   def test_download(self):
@@ -79,14 +103,81 @@ class TestDataset(absltest.TestCase):
 
     floorplan, device_layout_map = ds.get_floorplan('sb1')
 
-    # TODO:
-    #breakpoint()
-    print(type(floorplan), type(device_layout_map))
+    # FLOORPLAN
 
-    #self.assertIsInstance(floorplan, np.ndarray)
-    #self.assertIsInstance(device_layout_map, dict)
-    #self.assertGreater(floorplan.shape[0], 0)
-    #self.assertIn('device_name_example', device_layout_map)
+    self.assertIsInstance(floorplan, np.ndarray)
+    self.assertEqual(floorplan.shape, (744, 1004))
+    values, counts = np.unique(floorplan, return_counts=True)
+    value_counts = dict(zip(values, counts))
+    self.assertEqual(value_counts, {0.0: 436332, 1.0: 60204, 2.0: 250440})
+
+    # DEVICE LAYOUT MAP
+
+    self.assertIsInstance(device_layout_map, dict)
+    device_keys = sorted(list(device_layout_map.keys()))
+    expected_device_keys = [
+        'VAV CO 1-1-06',
+        'VAV CO 1-1-07 CO2',
+        'VAV CO 1-1-08 CO2',
+        'VAV CO 1-1-10 CO2',
+        'VAV CO 1-1-13 CO2',
+        'VAV CO 1-1-16 CO2',
+        'VAV CO 1-1-17 CO2',
+        'VAV CO 1-1-18 CO2',
+        'VAV CO 1-1-26',
+        'VAV CO 1-1-27',
+        'VAV CO 1-1-35 CO2',
+        'VAV CO 1-1-43',
+        'VAV CO 1-1-51',
+        'VAV RH 1-1-01',
+        'VAV RH 1-1-02',
+        'VAV RH 1-1-03',
+        'VAV RH 1-1-04',
+        'VAV RH 1-1-05',
+        'VAV RH 1-1-09 CO2',
+        'VAV RH 1-1-11',
+        'VAV RH 1-1-12 CO2',
+        'VAV RH 1-1-14 CO2',
+        'VAV RH 1-1-15',
+        'VAV RH 1-1-19',
+        'VAV RH 1-1-20',
+        'VAV RH 1-1-21',
+        'VAV RH 1-1-22',
+        'VAV RH 1-1-23',
+        'VAV RH 1-1-25 (MK # 1F9)',
+        'VAV RH 1-1-28 CO2 (Hearty Tech Talk 1H2)',
+        'VAV RH 1-1-29 CO2 (Hearty Tech Talk 1H2)',
+        'VAV RH 1-1-30 CO2 (Hearty Tech Talk 1H2)',
+        'VAV RH 1-1-31 CO2 (Hearty Tech Talk 1H2)',
+        'VAV RH 1-1-32 CO2 (Hearty Tech Talk 1H2)',
+        'VAV RH 1-1-33',
+        'VAV RH 1-1-34',
+        'VAV RH 1-1-36',
+        'VAV RH 1-1-37',
+        'VAV RH 1-1-38',
+        'VAV RH 1-1-39',
+        'VAV RH 1-1-40',
+        'VAV RH 1-1-41',
+        'VAV RH 1-1-42',
+        'VAV RH 1-1-44',
+        'VAV RH 1-1-45',
+        'VAV RH 1-1-46',
+        'VAV RH 1-1-47',
+        'VAV RH 1-1-48',
+        'VAV RH 1-1-49',
+        'VAV RH 1-1-50',
+        'VAV RH 1-1-52 CO2',
+        'VAV RH 1-1-53',
+        'VAV RH 1-1-54',
+        'VAV RH 1-1-55',
+    ]
+    self.assertEqual(device_keys, expected_device_keys)
+    # each device layout map is a list of two integer values:
+    first_layout_map = device_layout_map['VAV CO 1-1-06']
+    self.assertIsInstance(first_layout_map, list)
+    self.assertEqual(np.array(first_layout_map).shape, (1021, 2))
+    self.assertEqual(first_layout_map[0], [79, 35])
+    self.assertEqual(first_layout_map[-1], [80, 64])
 
   @unittest.skipUnless(TEST_DATASET_DOWNLOAD, SKIP_REASON)
   def test_get_building_data(self):
@@ -109,105 +200,134 @@ class TestDataset(absltest.TestCase):
     #
 
     self.assertIsInstance(metadata, dict)
-    metadata_keys = ['action_ids', 'action_timestamps', 'device_infos',
-                     'observation_ids', 'observation_timestamps', 'reward_ids',
-                     'reward_info_timestamps', 'reward_timestamps', 'zone_infos'
-                     ]
+    metadata_keys = [
+        'action_ids',
+        'action_timestamps',
+        'device_infos',
+        'observation_ids',
+        'observation_timestamps',
+        'reward_ids',
+        'reward_info_timestamps',
+        'reward_timestamps',
+        'zone_infos',
+    ]
     self.assertEqual(sorted(metadata.keys()), metadata_keys)
+
+    # action_timestamps:
+    self._assert_timestamps(
+        metadata['action_timestamps'],
+        earliest='2022-01-01 00:00:00+00:00',
+        latest='2022-06-30 00:55:00+00:00',
+        length=51852,
+    )
+
+    # observation_timestamps:
+    self._assert_timestamps(
+        metadata['observation_timestamps'],
+        earliest='2022-01-01 00:00:00+00:00',
+        latest='2022-06-30 00:55:00+00:00',
+        length=51852,
+    )
+
+    # reward_info_timestamps:
+    self._assert_timestamps(
+        metadata['reward_info_timestamps'],
+        earliest='2021-12-31 23:55:00+00:00',
+        latest='2022-06-30 00:50:00+00:00',
+        length=51852,
+    )
+
+    # reward_timestamps:
+    self._assert_timestamps(
+        metadata['reward_timestamps'],
+        earliest='2021-12-31 23:55:00+00:00',
+        latest='2022-06-30 00:50:00+00:00',
+        length=51852,
+    )
 
     # action_ids:
     action_ids = {
-      '12945159110931775488@supply_air_temperature_setpoint': 0,
-      '13761436543392677888@supply_water_temperature_setpoint': 1,
-      '14409954889734029312@supply_air_temperature_setpoint': 2
+        '12945159110931775488@supply_air_temperature_setpoint': 0,
+        '13761436543392677888@supply_water_temperature_setpoint': 1,
+        '14409954889734029312@supply_air_temperature_setpoint': 2,
     }
     self.assertEqual(metadata['action_ids'], action_ids)
 
-    # action_timestamps:
-    self.assertEqual(len(metadata['action_timestamps']), 173)
-    first_timestamp = metadata['action_timestamps'][0]
-    last_timestamp = metadata['action_timestamps'][-1]
-    self.assertIsInstance(first_timestamp, pd._libs.tslibs.timestamps.Timestamp)
-    self.assertIsInstance(last_timestamp, pd._libs.tslibs.timestamps.Timestamp)
-    self.assertEqual(str(first_timestamp), '2022-01-01 00:00:00+00:00')
-    self.assertEqual(str(last_timestamp),  '2022-06-30 00:55:00+00:00')
-
     # device_infos:
+    self.assertIsInstance(metadata['device_infos'], list)
     self.assertEqual(len(metadata['device_infos']), 173)
     first_device_info = {
-      'device_id': '202194278473007104',
-      'namespace': 'PHRED',
-      'code': 'SB1:AHU:AC-2',
-      'zone_id': '',
-      'device_type': 6,
-      'observable_fields': {
-        'building_air_static_pressure_sensor': 1,
-        'outside_air_flowrate_sensor': 1,
-        'supply_fan_speed_percentage_command': 1,
-        'supply_air_temperature_sensor': 1,
-        'supply_fan_speed_frequency_sensor': 1,
-        'supply_air_static_pressure_setpoint': 1,
-        'return_air_temperature_sensor': 1,
-        'mixed_air_temperature_setpoint': 1,
-        'exhaust_fan_speed_percentage_command': 1,
-        'exhaust_fan_speed_frequency_sensor': 1,
-        'outside_air_damper_percentage_command': 1,
-        'mixed_air_temperature_sensor': 1,
-        'exhaust_air_damper_percentage_command': 1,
-        'cooling_percentage_command': 1,
-        'outside_air_flowrate_setpoint': 1,
-        'supply_air_temperature_setpoint': 1,
-        'building_air_static_pressure_setpoint': 1,
-        'supply_air_static_pressure_sensor': 1
-      },
-      'action_fields': {
-        'exhaust_air_damper_percentage_command': 1,
-        'supply_air_temperature_setpoint': 1,
-        'supply_fan_speed_percentage_command': 1,
-        'outside_air_flowrate_setpoint': 1,
-        'cooling_percentage_command': 1,
-        'mixed_air_temperature_setpoint': 1,
-        'exhaust_fan_speed_percentage_command': 1,
-        'outside_air_damper_percentage_command': 1,
-        'supply_air_static_pressure_setpoint': 1,
-        'building_air_static_pressure_setpoint': 1
-      }
+        'device_id': '202194278473007104',
+        'namespace': 'PHRED',
+        'code': 'SB1:AHU:AC-2',
+        'zone_id': '',
+        'device_type': 6,
+        'observable_fields': {
+            'building_air_static_pressure_sensor': 1,
+            'outside_air_flowrate_sensor': 1,
+            'supply_fan_speed_percentage_command': 1,
+            'supply_air_temperature_sensor': 1,
+            'supply_fan_speed_frequency_sensor': 1,
+            'supply_air_static_pressure_setpoint': 1,
+            'return_air_temperature_sensor': 1,
+            'mixed_air_temperature_setpoint': 1,
+            'exhaust_fan_speed_percentage_command': 1,
+            'exhaust_fan_speed_frequency_sensor': 1,
+            'outside_air_damper_percentage_command': 1,
+            'mixed_air_temperature_sensor': 1,
+            'exhaust_air_damper_percentage_command': 1,
+            'cooling_percentage_command': 1,
+            'outside_air_flowrate_setpoint': 1,
+            'supply_air_temperature_setpoint': 1,
+            'building_air_static_pressure_setpoint': 1,
+            'supply_air_static_pressure_sensor': 1,
+        },
+        'action_fields': {
+            'exhaust_air_damper_percentage_command': 1,
+            'supply_air_temperature_setpoint': 1,
+            'supply_fan_speed_percentage_command': 1,
+            'outside_air_flowrate_setpoint': 1,
+            'cooling_percentage_command': 1,
+            'mixed_air_temperature_setpoint': 1,
+            'exhaust_fan_speed_percentage_command': 1,
+            'outside_air_damper_percentage_command': 1,
+            'supply_air_static_pressure_setpoint': 1,
+            'building_air_static_pressure_setpoint': 1,
+        },
     }
     self.assertEqual(metadata['device_infos'][0], first_device_info)
 
-<<<<<<< HEAD
-  # def test_get_floorplan(self):
-  #  ds = SmartBuildingsDataset()
-  #
-  #  result = ds.get_floorplan("sb1")
-  #  self.assertEqual()
-
-  # def test_get_building_data(self):
-  #  ds = SmartBuildingsDataset()
-  #
-  #  result = get_building_data("sb1", "2022_a")
-  #  self.assertEqual()
-=======
-
     # observation_ids:
-
-
-    # observation_timestamps:
->>>>>>> c6dab15 (Dataset tests - WIP)
-
+    self.assertIsInstance(metadata['observation_ids'], dict)
+    self.assertEqual(len(metadata['observation_ids']), 1198)
+    # an example key / value pair that exists:
+    self.assertEqual(
+        metadata['observation_ids']['202194278473007104@building_air_static_pressure_setpoint'],  # pylint:disable=line-too-long
+        0,
+    )
 
     # reward_ids:
-
-
-    # reward_info_timestamps:
-
-
-    # reward_timestamps:
-
+    self.assertIsInstance(metadata['reward_ids'], dict)
+    self.assertEqual(len(metadata['reward_ids']), 3252)
+    # an example key / value pair that exists:
+    self.assertEqual(
+        metadata['reward_ids']['rooms/9028552126@heating_setpoint_temperature'],
+        0,
+    )
 
     # 'zone_infos':
-
-
+    self.assertIsInstance(metadata['zone_infos'], list)
+    self.assertEqual(len(metadata['zone_infos']), 563)
+    first_zone_info = {
+        'zone_id': 'rooms/1002000133978',
+        'building_id': 'buildings/3616672508',
+        'zone_description': 'SB1-2-C2054',
+        'area': 0.0,
+        'zone_type': 1,
+        'floor': 2,
+        'devices': ['2618581107144046', '2696593986887004'],
+    }
+    self.assertEqual(metadata['zone_infos'][0], first_zone_info)
 
 
 if __name__ == '__main__':

--- a/smart_control/dataset/dataset_test.py
+++ b/smart_control/dataset/dataset_test.py
@@ -1,0 +1,61 @@
+"""Tests for SmartBuildingsDataset"""
+
+import os
+import shutil
+import unittest
+
+from absl.testing import absltest
+from dotenv import load_dotenv
+
+from smart_control.dataset.dataset import DATA_DIR
+from smart_control.dataset.dataset import SmartBuildingsDataset
+
+load_dotenv()
+
+TEST_DATASET_DOWNLOAD = bool(os.getenv("TEST_DATASET_DOWNLOAD", default="false").lower() == "true")  # pylint: disable=line-too-long
+
+
+class TestDataset(absltest.TestCase):
+  """Tests for the Smart Buildings Dataset"""
+
+  def test_data_dir(self):
+    self.assertTrue(os.path.isdir(DATA_DIR))
+
+  @unittest.skipUnless(TEST_DATASET_DOWNLOAD, "Skip large download by default.")
+  def test_download(self):
+    # NOTE: currently this is an end-to-end test, but takes around 2 minutes.
+    # We are skipping by default to keep the build fast.
+    # If you would like to run it periodically, locally:
+    # set the `TEST_DATASET_DOWNLOAD` env var to "true"
+    # TODO: consider adding a mocked version of the test as well
+
+    dataset_dirpath = os.path.join(DATA_DIR, "sb1")
+    zip_filepath = os.path.join(DATA_DIR, "sb1.zip")
+
+    shutil.rmtree(dataset_dirpath)
+    if os.path.exists(zip_filepath):
+      os.remove(zip_filepath)
+    self.assertFalse(os.path.isdir(dataset_dirpath))
+    self.assertFalse(os.path.exists(zip_filepath))
+
+    ds = SmartBuildingsDataset()
+    ds.download()
+
+    self.assertTrue(os.path.isdir(dataset_dirpath))
+    self.assertTrue(os.path.exists(zip_filepath))
+
+  # def test_get_floorplan(self):
+  #  ds = SmartBuildingsDataset()
+  #
+  #  result = ds.get_floorplan("sb1")
+  #  self.assertEqual()
+
+  # def test_get_building_data(self):
+  #  ds = SmartBuildingsDataset()
+  #
+  #  result = get_building_data("sb1", "2022_a")
+  #  self.assertEqual()
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/smart_control/dataset/dataset_test.py
+++ b/smart_control/dataset/dataset_test.py
@@ -6,44 +6,176 @@ import unittest
 
 from absl.testing import absltest
 from dotenv import load_dotenv
+import numpy as np
+import pandas as pd
 
 from smart_control.dataset.dataset import DATA_DIR
 from smart_control.dataset.dataset import SmartBuildingsDataset
 
 load_dotenv()
 
-TEST_DATASET_DOWNLOAD = bool(os.getenv("TEST_DATASET_DOWNLOAD", default="false").lower() == "true")  # pylint: disable=line-too-long
+TEST_DATASET_DOWNLOAD = bool(os.getenv('TEST_DATASET_DOWNLOAD', default='false').lower() == 'true') # pylint: disable=line-too-long
+
+DATASET_DIRPATH = os.path.join(DATA_DIR, 'sb1')
+ZIP_FILEPATH = os.path.join(DATA_DIR, 'sb1.zip')
+
+SKIP_REASON = 'Skip large download by default.'
 
 
-class TestDataset(absltest.TestCase):
-  """Tests for the Smart Buildings Dataset"""
+def cleanup_files():
+  if os.path.exists(ZIP_FILEPATH):
+    os.remove(ZIP_FILEPATH)
+
+  if os.path.exists(DATASET_DIRPATH):
+    shutil.rmtree(DATASET_DIRPATH)
+
+
+class TestDataDirectory(absltest.TestCase):
+  """Tests for the data directory."""
 
   def test_data_dir(self):
     self.assertTrue(os.path.isdir(DATA_DIR))
 
-  @unittest.skipUnless(TEST_DATASET_DOWNLOAD, "Skip large download by default.")
+
+class TestDataset(absltest.TestCase):
+  """Tests for the Smart Buildings Dataset, using real downloaded data.
+
+  It takes around two minutes to download the data, so we are skipping these
+  tests by default, to keep the build fast. But you can run them manually by
+  setting the `TEST_DATASET_DOWNLOAD` environment variable to 'true'.
+
+  TODO: consider adding a mocked variation as well.
+  """
+
+  ds = None
+
+  @classmethod
+  def setUpClass(cls):
+    if TEST_DATASET_DOWNLOAD:
+      cleanup_files()
+      assert not os.path.isdir(DATASET_DIRPATH)
+      assert not os.path.exists(ZIP_FILEPATH)
+
+      cls.ds = SmartBuildingsDataset(download=True)
+
+      assert os.path.isdir(DATASET_DIRPATH)
+      assert os.path.exists(ZIP_FILEPATH)
+
+  #@classmethod
+  #def tearDownClass(cls):
+  #  if TEST_DATASET_DOWNLOAD:
+  #    cleanup_files()
+  #    assert not os.path.isdir(DATASET_DIRPATH)
+  #    assert not os.path.exists(ZIP_FILEPATH)
+
+  @unittest.skipUnless(TEST_DATASET_DOWNLOAD, SKIP_REASON)
   def test_download(self):
-    # NOTE: currently this is an end-to-end test, but takes around 2 minutes.
-    # We are skipping by default to keep the build fast.
-    # If you would like to run it periodically, locally:
-    # set the `TEST_DATASET_DOWNLOAD` env var to "true"
-    # TODO: consider adding a mocked version of the test as well
+    self.assertTrue(os.path.isdir(DATASET_DIRPATH))
+    self.assertTrue(os.path.exists(ZIP_FILEPATH))
 
-    dataset_dirpath = os.path.join(DATA_DIR, "sb1")
-    zip_filepath = os.path.join(DATA_DIR, "sb1.zip")
+  @unittest.skipUnless(TEST_DATASET_DOWNLOAD, SKIP_REASON)
+  def test_get_floorplan(self):
+    ds = self.ds
 
-    shutil.rmtree(dataset_dirpath)
-    if os.path.exists(zip_filepath):
-      os.remove(zip_filepath)
-    self.assertFalse(os.path.isdir(dataset_dirpath))
-    self.assertFalse(os.path.exists(zip_filepath))
+    floorplan, device_layout_map = ds.get_floorplan('sb1')
 
-    ds = SmartBuildingsDataset()
-    ds.download()
+    # TODO:
+    #breakpoint()
+    print(type(floorplan), type(device_layout_map))
 
-    self.assertTrue(os.path.isdir(dataset_dirpath))
-    self.assertTrue(os.path.exists(zip_filepath))
+    #self.assertIsInstance(floorplan, np.ndarray)
+    #self.assertIsInstance(device_layout_map, dict)
+    #self.assertGreater(floorplan.shape[0], 0)
+    #self.assertIn('device_name_example', device_layout_map)
 
+  @unittest.skipUnless(TEST_DATASET_DOWNLOAD, SKIP_REASON)
+  def test_get_building_data(self):
+    ds = self.ds
+
+    data, metadata = ds.get_building_data('sb1', '2022_a')
+
+    #
+    # DATA
+    #
+
+    self.assertIsInstance(data, np.lib.npyio.NpzFile)
+    self.assertEqual(data['observation_value_matrix'].shape, (51852, 1198))
+    self.assertEqual(data['action_value_matrix'].shape, (51852, 3))
+    self.assertEqual(data['reward_value_matrix'].shape, (51852, 17))
+    self.assertEqual(data['reward_info_value_matrix'].shape, (51852, 3252))
+
+    #
+    # METADATA
+    #
+
+    self.assertIsInstance(metadata, dict)
+    metadata_keys = ['action_ids', 'action_timestamps', 'device_infos',
+                     'observation_ids', 'observation_timestamps', 'reward_ids',
+                     'reward_info_timestamps', 'reward_timestamps', 'zone_infos'
+                     ]
+    self.assertEqual(sorted(metadata.keys()), metadata_keys)
+
+    # action_ids:
+    action_ids = {
+      '12945159110931775488@supply_air_temperature_setpoint': 0,
+      '13761436543392677888@supply_water_temperature_setpoint': 1,
+      '14409954889734029312@supply_air_temperature_setpoint': 2
+    }
+    self.assertEqual(metadata['action_ids'], action_ids)
+
+    # action_timestamps:
+    self.assertEqual(len(metadata['action_timestamps']), 173)
+    first_timestamp = metadata['action_timestamps'][0]
+    last_timestamp = metadata['action_timestamps'][-1]
+    self.assertIsInstance(first_timestamp, pd._libs.tslibs.timestamps.Timestamp)
+    self.assertIsInstance(last_timestamp, pd._libs.tslibs.timestamps.Timestamp)
+    self.assertEqual(str(first_timestamp), '2022-01-01 00:00:00+00:00')
+    self.assertEqual(str(last_timestamp),  '2022-06-30 00:55:00+00:00')
+
+    # device_infos:
+    self.assertEqual(len(metadata['device_infos']), 173)
+    first_device_info = {
+      'device_id': '202194278473007104',
+      'namespace': 'PHRED',
+      'code': 'SB1:AHU:AC-2',
+      'zone_id': '',
+      'device_type': 6,
+      'observable_fields': {
+        'building_air_static_pressure_sensor': 1,
+        'outside_air_flowrate_sensor': 1,
+        'supply_fan_speed_percentage_command': 1,
+        'supply_air_temperature_sensor': 1,
+        'supply_fan_speed_frequency_sensor': 1,
+        'supply_air_static_pressure_setpoint': 1,
+        'return_air_temperature_sensor': 1,
+        'mixed_air_temperature_setpoint': 1,
+        'exhaust_fan_speed_percentage_command': 1,
+        'exhaust_fan_speed_frequency_sensor': 1,
+        'outside_air_damper_percentage_command': 1,
+        'mixed_air_temperature_sensor': 1,
+        'exhaust_air_damper_percentage_command': 1,
+        'cooling_percentage_command': 1,
+        'outside_air_flowrate_setpoint': 1,
+        'supply_air_temperature_setpoint': 1,
+        'building_air_static_pressure_setpoint': 1,
+        'supply_air_static_pressure_sensor': 1
+      },
+      'action_fields': {
+        'exhaust_air_damper_percentage_command': 1,
+        'supply_air_temperature_setpoint': 1,
+        'supply_fan_speed_percentage_command': 1,
+        'outside_air_flowrate_setpoint': 1,
+        'cooling_percentage_command': 1,
+        'mixed_air_temperature_setpoint': 1,
+        'exhaust_fan_speed_percentage_command': 1,
+        'outside_air_damper_percentage_command': 1,
+        'supply_air_static_pressure_setpoint': 1,
+        'building_air_static_pressure_setpoint': 1
+      }
+    }
+    self.assertEqual(metadata['device_infos'][0], first_device_info)
+
+<<<<<<< HEAD
   # def test_get_floorplan(self):
   #  ds = SmartBuildingsDataset()
   #
@@ -55,7 +187,28 @@ class TestDataset(absltest.TestCase):
   #
   #  result = get_building_data("sb1", "2022_a")
   #  self.assertEqual()
+=======
+
+    # observation_ids:
 
 
-if __name__ == "__main__":
+    # observation_timestamps:
+>>>>>>> c6dab15 (Dataset tests - WIP)
+
+
+    # reward_ids:
+
+
+    # reward_info_timestamps:
+
+
+    # reward_timestamps:
+
+
+    # 'zone_infos':
+
+
+
+
+if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
Tests the `SmartBuildingsDataset` class defined in "smart_control/dataset/dataset.py".

Details:

  + Moves the dataset download directory from the root directory to a new "data" directory. This helps keep the root directory free of clutter. Ensures the downloaded files are ignored from version control because they are large.

  + Updates the dataset download functionality to read from existing local files if present. This prevents unnecessary re-downloading and streamlines the dataset loading process.

  + Adds tests for the dataset download process, as well as to describe the structure of the resulting data. This includes high fidelity end-to-end tests for dataset downloading. Skips these tests by default, because it takes around two minutes to download the data and we don't want to slow down the build. However we can run these tests periodically as desired by passing a `TEST_DATASET_DOWNLOAD` environment variable. The presence of these tests, even if not always run, is helpful for reading and understanding the behavior of the code.


