### PR TITLE
fix: Replaced assert with ValueError in stochastic_occupancy

### DIFF
--- a/smart_control/simulator/stochastic_occupancy.py
+++ b/smart_control/simulator/stochastic_occupancy.py
@@ -54,13 +54,22 @@ class ZoneOccupant:
       random_state: np.random.RandomState,
       time_zone: Union[datetime.tzinfo, str] = "UTC",
   ):
-    assert (
+    # Validate that the time bounds are in chronological order
+    if not (
         earliest_expected_arrival_hour
         < latest_expected_arrival_hour
         < earliest_expected_departure_hour
         < latest_expected_departure_hour
-    )
-    assert lunch_start_hour < lunch_end_hour
+    ):
+      raise ValueError(
+          "Time bounds must be in chronological order i.e., "
+          "expected arrival/departure hours must be strictly increasing:" "earliest_expected_arrival_hour < latest_expected_arrival_hour "
+          "< earliest_expected_departure_hour < latest_expected_departure_hour."
+      )
+
+    # Validate lunch time bounds
+    if lunch_start_hour >= lunch_end_hour:
+      raise ValueError("lunch_start_hour must be before lunch_end_hour.")
 
     self._earliest_expected_arrival_hour = earliest_expected_arrival_hour
     self._latest_expected_arrival_hour = latest_expected_arrival_hour


### PR DESCRIPTION
Fixes #28

This pull request resolves the issue by replacing `assert` statements with explicit `ValueError` exceptions in the example file mentioned, `smart_control/simulator/stochastic_occupancy.py`.

Using `ValueError` is better practice as `assert` statements can be disabled in production environments, which would otherwise silently ignore important precondition checks.

- [x] Tests pass
- [x] No documentation changes were necessary for this change.