### PR TITLE
refactor: Modernize super() calls in sac_networks 

### DIFF
--- a/smart_control/reinforcement_learning/agents/networks/sac_networks.py
+++ b/smart_control/reinforcement_learning/agents/networks/sac_networks.py
@@ -109,14 +109,14 @@ class _TanhNormalProjectionNetworkWrapper(
   """Wrapper to pass predefined `outer_rank` to underlying projection net."""
 
   def __init__(self, sample_spec, predefined_outer_rank=1):
-    super(_TanhNormalProjectionNetworkWrapper, self).__init__(sample_spec)
+    super().__init__(sample_spec)
     self.predefined_outer_rank = predefined_outer_rank
 
   def call(self, inputs, **kwargs):
     kwargs['outer_rank'] = self.predefined_outer_rank
     if 'step_type' in kwargs:
       del kwargs['step_type']
-    return super(_TanhNormalProjectionNetworkWrapper, self).call(
+    return super().call(
         inputs, **kwargs
     )
 


### PR DESCRIPTION
### Summary

This PR addresses issue **#35** by refactoring the `_TanhNormalProjectionNetworkWrapper` class to use the modern, argument-less `super()` syntax. This change improves code readability and aligns the codebase with current Python 3 best practices without altering functionality.

### Technical Explanation

The previous implementation in `sac_networks.py` used the `super(_TanhNormalProjectionNetworkWrapper, self)` syntax. While functionally correct, this is an explicit and verbose style inherited from Python 2. It can be confusing as it appears to call `super()` on the class itself.

The goal of `super()` is to call the method from the parent class in the Method Resolution Order (MRO), which in this case is `tanh_normal_projection_network.TanhNormalProjectionNetwork`. The modern `super()` call automatically handles this, making the code cleaner, more maintainable, and less prone to copy-paste errors if the class were ever to be renamed.

This refactoring replaces the outdated calls with `super()`, which is the idiomatic standard in Python 3.

### Changes Made

- Updated the `__init__` method in `_TanhNormalProjectionNetworkWrapper` to use `super().__init__(...)`.
- Updated the `call` method in `_TanhNormalProjectionNetworkWrapper` to use `super().call(...)`.

### Validation 

To ensure this refactoring did not introduce any regressions, the full project test suite was executed using `pytest`.

- **Test Command:** `pytest`
- **Result:** **671 passed, 38 skipped, 0 failed**

The successful test run validates that this change is safe and does not impact existing behavior.

Fixes #35

- [x] Tests pass
- [x] No documentation changes were necessary for this change.