### PR TITLE
Fix Intel-based macOS build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,12 +22,8 @@ jobs:
         python-version: ['3.10.15', '3.11']
 
         include:
-          # temporarily disabling this Intel-based Mac OS run
-          # because of issues with underlying dependencies breaking the build
-          # see: https://github.com/google/sbsim/issues/126
-          #
-          #- os: macos-13 # intel-based
-          #  python-version: '3.11'
+          - os: macos-15-intel # updated intel-based
+            python-version: '3.11'
 
           - os: macos-latest # arm-based
             python-version: '3.11'


### PR DESCRIPTION
## Summary
Fixes the Intel-based macOS build failures by upgrading from the deprecated `macos-13` runner to the new `macos-15-intel` runner.

## Problem
The Intel-based macOS build was disabled due to build failures. Investigation revealed that the `macos-13` runner has been deprecated by GitHub Actions and is no longer receiving updates, causing the build to fail.

## Solution
- Updated the Intel Mac runner from `macos-13` to `macos-15-intel`
- Re-enabled the Intel-based macOS build that was temporarily disabled
- `macos-15-intel` is the official replacement for Intel-based macOS builds and will be supported until August 2027

## Testing
All CI builds are now passing:
- Ubuntu (Python 3.10.15, 3.11)
- macOS ARM (`macos-latest`)  
- macOS Intel (`macos-15-intel`)

Test run: https://github.com/AvishKaushik/sbsim/actions/runs/20201182727

## References
- [GitHub Actions: macOS 13 runner image is closing down](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/)
- [macOS 15 Intel-based image availability](https://github.com/actions/runner-images/issues/13045)

Resolves #126