### PR TITLE
Device Property Decorators

### DIFF
--- a/smart_control/simulator/air_handler_test.py
+++ b/smart_control/simulator/air_handler_test.py
@@ -444,7 +444,7 @@ class AirHandlerTest(parameterized.TestCase):
     )
 
     self.assertSameElements(
-        handler.observable_field_names(),
+        handler.observable_field_names,
         [
             'differential_pressure_setpoint',
             'supply_air_flowrate_sensor',
@@ -507,7 +507,7 @@ class AirHandlerTest(parameterized.TestCase):
         self.fan_efficiency,
     )
     self.assertSameElements(
-        handler.action_field_names(),
+        handler.action_field_names,
         [
             'supply_air_heating_temperature_setpoint',
             'supply_air_cooling_temperature_setpoint',

--- a/smart_control/simulator/boiler_test.py
+++ b/smart_control/simulator/boiler_test.py
@@ -247,12 +247,12 @@ class BoilerTest(parameterized.TestCase):
     b = self.get_default_boiler()
 
     self.assertSameElements(
-      b.observable_field_names,
-      [
-        'supply_water_setpoint',
-        'supply_water_temperature_sensor',
-        'heating_request_count',
-      ],
+        b.observable_field_names,
+        [
+            'supply_water_setpoint',
+            'supply_water_temperature_sensor',
+            'heating_request_count',
+        ],
     )
 
   def test_observe_supply_water_setpoint(self):

--- a/smart_control/simulator/boiler_test.py
+++ b/smart_control/simulator/boiler_test.py
@@ -247,12 +247,12 @@ class BoilerTest(parameterized.TestCase):
     b = self.get_default_boiler()
 
     self.assertSameElements(
-        b.observable_field_names(),
-        [
-            'supply_water_setpoint',
-            'supply_water_temperature_sensor',
-            'heating_request_count',
-        ],
+      b.observable_field_names,
+      [
+        'supply_water_setpoint',
+        'supply_water_temperature_sensor',
+        'heating_request_count',
+      ],
     )
 
   def test_observe_supply_water_setpoint(self):
@@ -432,7 +432,7 @@ class BoilerTest(parameterized.TestCase):
   def test_action_field_names(self):
     b = self.get_default_boiler()
 
-    self.assertSameElements(b.action_field_names(), ['supply_water_setpoint'])
+    self.assertSameElements(b.action_field_names, ['supply_water_setpoint'])
 
   def test_action_supply_water_setpoint(self):
     b = self.get_default_boiler()
@@ -456,7 +456,7 @@ class BoilerTest(parameterized.TestCase):
   def test_device_id(self):
     b = self.get_default_boiler()
 
-    device_id = b.device_id()
+    device_id = b.device_id
 
     self.assertEqual(device_id, 'boiler_id')
 

--- a/smart_control/simulator/simulator.py
+++ b/smart_control/simulator/simulator.py
@@ -795,7 +795,7 @@ class Simulator:
     This data is used to compute the instantaneous reward.
     """
     air_handler_reward_infos = {}
-    air_handler_id = self._hvac.air_handler.device_id()
+    air_handler_id = self._hvac.air_handler.device_id
     blower_electrical_energy_rate = (
         self._hvac.air_handler.compute_intake_fan_energy_rate()
         + self._hvac.air_handler.compute_exhaust_fan_energy_rate()
@@ -824,7 +824,7 @@ class Simulator:
     This data is used to compute the instantaneous reward.
     """
     boiler_reward_infos = {}
-    boiler_id = self._hvac.boiler.device_id()
+    boiler_id = self._hvac.boiler.device_id
     return_water_temp = self._hvac.boiler.return_water_temperature_sensor
     natural_gas_heating_energy_rate = (
         self._hvac.boiler.compute_thermal_energy_rate(

--- a/smart_control/simulator/simulator_building.py
+++ b/smart_control/simulator/simulator_building.py
@@ -60,7 +60,7 @@ class SimulatorBuilding(BaseBuilding):
         (hvac.air_handler, self._create_device_info(hvac.air_handler)),
     ]
     all_devices.extend([
-        (vav, self._create_device_info(vav, vav.zone_id()))
+        (vav, self._create_device_info(vav, vav.zone_id))
         for vav in hvac.vavs.values()
     ])
 
@@ -96,11 +96,11 @@ class SimulatorBuilding(BaseBuilding):
       device: SmartDevice to create info object for.
       zone_id: Zone Id of the device.
     """
-    observable_fields = device.observable_field_names()
-    action_fields = device.action_field_names()
+    observable_fields = device.observable_field_names
+    action_fields = device.action_field_names
 
     device_info = smart_control_building_pb2.DeviceInfo()
-    device_info.device_id = device.device_id()
+    device_info.device_id = device.device_id
     device_info.namespace = f"device_namespace_{uuid.uuid4()}"
     device_info.code = f"device_code_{uuid.uuid4()}"
     device_info.zone_id = zone_id

--- a/smart_control/simulator/simulator_flexible_floor_plan.py
+++ b/smart_control/simulator/simulator_flexible_floor_plan.py
@@ -238,7 +238,7 @@ class SimulatorFlexibleGeometries(simulator.Simulator):
     This data is used to compute the instantaneous reward.
     """
     air_handler_reward_infos = {}
-    air_handler_id = self._hvac.air_handler.device_id()
+    air_handler_id = self._hvac.air_handler.device_id
     blower_electrical_energy_rate = (
         self._hvac.air_handler.compute_intake_fan_energy_rate()
         + self._hvac.air_handler.compute_exhaust_fan_energy_rate()
@@ -267,7 +267,7 @@ class SimulatorFlexibleGeometries(simulator.Simulator):
     This data is used to compute the instantaneous reward.
     """
     boiler_reward_infos = {}
-    boiler_id = self._hvac.boiler.device_id()
+    boiler_id = self._hvac.boiler.device_id
     return_water_temp = self._hvac.boiler.return_water_temperature_sensor
     natural_gas_heating_energy_rate = (
         self._hvac.boiler.compute_thermal_energy_rate(

--- a/smart_control/simulator/simulator_flexible_floor_plan_test.py
+++ b/smart_control/simulator/simulator_flexible_floor_plan_test.py
@@ -1505,7 +1505,7 @@ class FlexibleFloorplanSimulatorTest(parameterized.TestCase):
     self.assertEqual(reward_info.zone_reward_infos, expected_zone_reward_infos)
 
     air_handler_reward_info = reward_info.air_handler_reward_infos[
-        sim._hvac.air_handler.device_id()
+        sim._hvac.air_handler.device_id
     ]
 
     blower_electrical_energy_rate = (
@@ -1533,7 +1533,7 @@ class FlexibleFloorplanSimulatorTest(parameterized.TestCase):
     )
 
     boiler_reward_info = reward_info.boiler_reward_infos[
-        sim._hvac.boiler.device_id()
+        sim._hvac.boiler.device_id
     ]
     natural_gas_heating_energy_rate = (
         sim._hvac.boiler.compute_thermal_energy_rate(

--- a/smart_control/simulator/simulator_test.py
+++ b/smart_control/simulator/simulator_test.py
@@ -1053,7 +1053,7 @@ class SimulatorTest(parameterized.TestCase):
     self.assertEqual(reward_info.zone_reward_infos, expected_zone_reward_infos)
 
     air_handler_reward_info = reward_info.air_handler_reward_infos[
-        sim._hvac.air_handler.device_id()
+        sim._hvac.air_handler.device_id
     ]
 
     blower_electrical_energy_rate = (
@@ -1081,7 +1081,7 @@ class SimulatorTest(parameterized.TestCase):
     )
 
     boiler_reward_info = reward_info.boiler_reward_infos[
-        sim._hvac.boiler.device_id()
+        sim._hvac.boiler.device_id
     ]
     natural_gas_heating_energy_rate = (
         sim._hvac.boiler.compute_thermal_energy_rate(

--- a/smart_control/simulator/smart_device.py
+++ b/smart_control/simulator/smart_device.py
@@ -64,6 +64,7 @@ class SmartDevice(metaclass=abc.ABCMeta):
   def device_id(self) -> str:
     """Returns device id."""
     return self._device_id
+
   @property
   def zone_id(self) -> Optional[str]:
     """Returns zone_id."""

--- a/smart_control/simulator/smart_device.py
+++ b/smart_control/simulator/smart_device.py
@@ -60,13 +60,10 @@ class SmartDevice(metaclass=abc.ABCMeta):
     self._action_timestamp = None
     self._observation_timestamp = None
 
-
   @property
   def device_id(self) -> str:
     """Returns device id."""
     return self._device_id
-
-
   @property
   def zone_id(self) -> Optional[str]:
     """Returns zone_id."""
@@ -76,12 +73,10 @@ class SmartDevice(metaclass=abc.ABCMeta):
     """Returns device type."""
     return self._device_type
 
-
   @property
   def observable_field_names(self) -> Sequence[str]:
     """Returns all observable field names."""
     return self._observable_fields.keys()  # pytype: disable=bad-return-type
-
 
   @property
   def action_field_names(self) -> Sequence[str]:

--- a/smart_control/simulator/smart_device.py
+++ b/smart_control/simulator/smart_device.py
@@ -60,10 +60,14 @@ class SmartDevice(metaclass=abc.ABCMeta):
     self._action_timestamp = None
     self._observation_timestamp = None
 
+
+  @property
   def device_id(self) -> str:
     """Returns device id."""
     return self._device_id
 
+
+  @property
   def zone_id(self) -> Optional[str]:
     """Returns zone_id."""
     return self._zone_id
@@ -72,10 +76,14 @@ class SmartDevice(metaclass=abc.ABCMeta):
     """Returns device type."""
     return self._device_type
 
+
+  @property
   def observable_field_names(self) -> Sequence[str]:
     """Returns all observable field names."""
     return self._observable_fields.keys()  # pytype: disable=bad-return-type
 
+
+  @property
   def action_field_names(self) -> Sequence[str]:
     """Returns all action field names."""
     return self._action_fields.keys()  # pytype: disable=bad-return-type

--- a/smart_control/simulator/smart_device_test.py
+++ b/smart_control/simulator/smart_device_test.py
@@ -49,26 +49,26 @@ class SmartDeviceTest(absltest.TestCase):
   def test_device_id(self):
     heater = self.heater_class()
 
-    self.assertEqual(heater.device_id(), 'heater_id')
+    self.assertEqual(heater.device_id, 'heater_id')
 
   def test_zone_id(self):
     heater = self.heater_class()
 
-    self.assertEqual(heater.zone_id(), 'zone_id')
+    self.assertEqual(heater.zone_id, 'zone_id')
 
   def test_observable_field_names(self):
     heater = self.heater_class()
 
     self.assertSameElements(
-        heater.observable_field_names(),
-        ['obs_temp', 'obs_heat_setting', 'obs_seconds_active', 'obs_bad'],
+      heater.observable_field_names,
+      ['obs_temp', 'obs_heat_setting', 'obs_seconds_active', 'obs_bad'],
     )
 
   def test_action_field_names(self):
     heater = self.heater_class()
 
     self.assertSameElements(
-        heater.action_field_names(), ['act_heat_setting', 'act_bad']
+      heater.action_field_names, ['act_heat_setting', 'act_bad']
     )
 
   def test_observable_type(self):

--- a/smart_control/simulator/vav_test.py
+++ b/smart_control/simulator/vav_test.py
@@ -425,7 +425,7 @@ class VavTest(parameterized.TestCase):
     v = vav.Vav(max_air_flow_rate, reheat_max_water_flow_rate, t, b)
 
     self.assertSameElements(
-      v.observable_field_names,
+        v.observable_field_names,
         [
             'supply_air_damper_percentage_command',
             'supply_air_flowrate_setpoint',
@@ -477,7 +477,7 @@ class VavTest(parameterized.TestCase):
     v = vav.Vav(max_air_flow_rate, reheat_max_water_flow_rate, t, b)
 
     self.assertSameElements(
-      v.action_field_names, ['supply_air_damper_percentage_command']
+        v.action_field_names, ['supply_air_damper_percentage_command']
     )
 
   def test_action_supply_air_flowrate_setpoint(self):

--- a/smart_control/simulator/vav_test.py
+++ b/smart_control/simulator/vav_test.py
@@ -425,7 +425,7 @@ class VavTest(parameterized.TestCase):
     v = vav.Vav(max_air_flow_rate, reheat_max_water_flow_rate, t, b)
 
     self.assertSameElements(
-        v.observable_field_names(),
+      v.observable_field_names,
         [
             'supply_air_damper_percentage_command',
             'supply_air_flowrate_setpoint',
@@ -477,7 +477,7 @@ class VavTest(parameterized.TestCase):
     v = vav.Vav(max_air_flow_rate, reheat_max_water_flow_rate, t, b)
 
     self.assertSameElements(
-        v.action_field_names(), ['supply_air_damper_percentage_command']
+      v.action_field_names, ['supply_air_damper_percentage_command']
     )
 
   def test_action_supply_air_flowrate_setpoint(self):


### PR DESCRIPTION
Fixes #135 

1. Added @property decorators to methods requested in SmartDevice.
2. Updated all code and test references to use attribute access (e.g., _device.device_id_ instead of _device.device_id(_)).
3. Searched and replaced all usages across the codebase, including:

- simulator.py
- simulator_building.py
- simulator_flexible_floor_plan.py

All relevant test files
**Note: No changes were made for _device_filepath_ as it was not found in the codebase.**

