### PR TITLE
docs: prep mkdocs edit_uri for copybara_push -> main rename (#119)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,9 @@ site_url: https://google.github.io/sbsim/
 repo_url: https://github.com/google/sbsim
 repo_name: google/sbsim
 # edit_uri will work after branch rename from copybara_push -> main
-edit_uri: edit/main/docs/
+# TODO(#119): After renaming default branch copybara_push -> main, update edit_uri.
+edit_uri: edit/copybara_push/docs/
+# edit_uri: edit/main/docs/
 
 #
 # THEME / STYLE

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,7 +14,8 @@ site_dir: docs_site # NOTE: should not be within the docs dir
 site_url: https://google.github.io/sbsim/
 repo_url: https://github.com/google/sbsim
 repo_name: google/sbsim
-edit_uri: edit/copybara_push/docs/
+# edit_uri will work after branch rename from copybara_push -> main
+edit_uri: edit/main/docs/
 
 #
 # THEME / STYLE


### PR DESCRIPTION
Fixes #119

> It's a good idea to open an issue first for discussion.

This PR is a small prep step for renaming the default branch from `copybara_push` to `main` (Issue #119).
Since `copybara_push` is likely tied to Copybara sync, the internal destination ref may need updating after the rename.

### What changed
- **mkdocs.yml**: Added notes to keep `edit_uri` pointing at `copybara_push` for now, and to update it to `main` after the branch rename (avoids breaking “Edit this page” links before `main` exists).

### Maintainer follow-ups (after merge)
- Rename branch in GitHub: `copybara_push` -> `main`
- Update `mkdocs.yml` `edit_uri` to `edit/main/docs/`
- Verify Copybara config/sync doesn’t hardcode `copybara_push`

- [ ] Tests pass (CI will confirm)
- [x] Appropriate changes to documentation are included in the PR
