### PR TITLE
Add Docker image build to CI

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,38 @@
+name: Docker CI Build
+
+on:
+  push:
+    branches:
+      - master
+      - main
+      - copybara_push
+  pull_request:
+    branches:
+      - master
+      - main
+      - copybara_push
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64
+          push: false
+          tags: sbsim:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max,ignore-error=true

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,13 +22,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
 
       - name: Build Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           platforms: linux/amd64


### PR DESCRIPTION
Fixes #178

Adds a dedicated GitHub Actions workflow that builds the Docker image on pushes and pull requests targeting `master`, `main`, or `copybara_push`.

The workflow uses Docker Buildx, does not publish the image, and caches dependency layers between builds. Cache export failures remain nonfatal so they cannot hide an image build failure.

## Testing

- `actionlint .github/workflows/docker-build.yml`
- `zizmor --format plain .github/workflows/docker-build.yml`

A full image build requires Docker and will run in the new CI job.

- [x] Relevant local checks pass
- [x] No documentation changes are needed