### PR TITLE
Add CI workflow to verify Docker build

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,0 +1,39 @@
+name: Docker Build
+
+on:
+  push:
+    branches:
+      - master
+      - main
+      - copybara_push
+    paths:
+      - 'Dockerfile'
+      - '.github/workflows/docker-build.yaml'
+  pull_request:
+    branches:
+      - master
+      - main
+      - copybara_push
+    paths:
+      - 'Dockerfile'
+      - '.github/workflows/docker-build.yaml'
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build Docker image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        push: false
+        tags: sbsim:ci-build
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -18,19 +18,22 @@ on:
       - 'Dockerfile'
       - '.github/workflows/docker-build.yaml'
 
+permissions:
+  contents: read
+
 jobs:
   docker-build:
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.2.2
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
     - name: Build Docker image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
       with:
         context: .
         push: false


### PR DESCRIPTION
Fixes #178,  the build verification part.

This adds a GitHub Actions workflow to build the project’s Dockerfile whenever a push or pull request changes either the Dockerfile or the workflow itself. It is meant to catch build breakage early, as requested.
It covers only the “building the Docker image” part of the issue. It does not include publishing or deployment to Docker Hub, GHCR, or any other location. That work requires registry credentials and a maintainer’s decision about where the images should live, so I’ve left it out for now. I can take it on in a follow-up PR if that would be useful.
It uses docker/build-push-action with push set to false, meaning it only builds and verifies the image; nothing is pushed anywhere. I added GitHub Actions layer caching with type=gha as well, which keeps repeated runs fast. The workflow triggers only when the Dockerfile or this workflow file changes, rather than running on every unrelated commit.