### PR TITLE
Configure Pyrefly tooling

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -77,6 +77,13 @@ jobs:
         source .venv/bin/activate
         pylint --rcfile=.pylintrc --ignore=proto smart_control
 
+    - name: Run the Python type checker
+      run: |
+        source .venv/bin/activate
+        # TODO(#174): Remove "|| true" after the upcoming internal code sync
+        # resolves existing Pyrefly findings in smart_control.
+        pyrefly check --config pyrefly.toml || true
+
     - name: Run the Markdown formatter
       run: |
         source .venv/bin/activate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,20 @@ repos:
       files: '^smart_control/'
       exclude: '^smart_control/proto/'
 
+    # TODO(#174): Make this blocking after the upcoming internal code sync
+    # resolves existing Pyrefly findings in smart_control.
+    - id: pyrefly
+      name: pyrefly
+      entry: >-
+        python -c "import subprocess; subprocess.run(['poetry', 'run',
+        'pyrefly', 'check', '--config', 'pyrefly.toml'])"
+      language: system
+      pass_filenames: false
+      types: [file, python]
+      files: '^smart_control/'
+      exclude: '^smart_control/proto/'
+      verbose: true
+
 # See: https://mdformat.readthedocs.io/en/stable/users/installation_and_usage.html#usage-as-a-pre-commit-hook
 - repo: https://github.com/hukkin/mdformat
   rev: 1.0.0

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -215,6 +215,23 @@ for a given message (e.g. "line-too-long") by adding a trailing comment of
 expression, or by wrapping multiple lines of code between
 `# pylint: disable=line-too-long` and `# pylint: enable=line-too-long` comments.
 
+### Python Type Checking
+
+We are using [`pyrefly`](https://pyrefly.org/) to type check Python code.
+Pyrefly uses the repository's `pyrefly.toml` configuration file, which matches
+Google's recommended open source configuration as closely as possible.
+
+The type checker runs as part of the pre-commit hooks and CI build. For now,
+Pyrefly reports findings without blocking commits or CI because the repository
+has existing type-checking findings that are expected to be addressed by an
+upcoming internal code sync.
+
+If you would like to run the type checker manually:
+
+```sh
+pyrefly check --config pyrefly.toml
+```
+
 ### Markdown Formatting
 
 We are using [`mdformat`](https://github.com/executablebooks/mdformat) with the

--- a/poetry.lock
+++ b/poetry.lock
@@ -3670,6 +3670,28 @@ files = [
 diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
+name = "pyrefly"
+version = "1.2.0"
+description = "A fast type checker and language server for Python with powerful IDE features"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "pyrefly-1.2.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7f46d983ac49ddd2b043694960a01dc6a19a5cfd8eec609d6bd9c42866f91b4e"},
+    {file = "pyrefly-1.2.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:756f669b5555090f5c1a4fef30db1785fabe657764f7e4e6dc88994dfb8ca82d"},
+    {file = "pyrefly-1.2.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e3465812ce5ef4781fb592edbf2724547296f0a3124be115d73c7e8b2401862d"},
+    {file = "pyrefly-1.2.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5de7b2ad2bba5c8055181681a84b74143eac2234a48ba5d1b7ed7e7a722b02bd"},
+    {file = "pyrefly-1.2.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:25822ea9505f589ea8a725e4268b475132fb89e038fbf092e446510443ac142a"},
+    {file = "pyrefly-1.2.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90efe75e17491ef5d636e10469e9278d7d0256b3b4c5e1f4750069bf3ae0f5d1"},
+    {file = "pyrefly-1.2.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:368aaf7eee4f511ddc0f8e564cf14e01ab2f10b0db9105c6d5b153bf498d07bf"},
+    {file = "pyrefly-1.2.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:d52d5da7bc65fb7675fbaa80eda879d4f8787c494f04cac21603330d3abbdbbe"},
+    {file = "pyrefly-1.2.0-py3-none-win32.whl", hash = "sha256:8c90751de8506d938e8f802659c74cf35bd7a0036510ee6c634a38eebb280bfa"},
+    {file = "pyrefly-1.2.0-py3-none-win_amd64.whl", hash = "sha256:8a8964c224ccc4882730130955815de21ff443c1ac3f0b90685b19bf63848170"},
+    {file = "pyrefly-1.2.0-py3-none-win_arm64.whl", hash = "sha256:3a90bb8df39dfbac74b1f3b2e9d7c526b8f80568884c3944d955023a73ebf61e"},
+    {file = "pyrefly-1.2.0.tar.gz", hash = "sha256:5485f960fc2481617068c918335c39ab1507ef90b6b5bd35bf57726e60e73185"},
+]
+
+[[package]]
 name = "pytest"
 version = "8.4.0"
 description = "pytest: simple powerful testing with Python"
@@ -5187,4 +5209,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.12"
-content-hash = "6f4ccbc80647b55d4eaa35df3f9e40be8342b9e7c4556a55530af455170c358a"
+content-hash = "f5e992fa04426f30f96bfe87bdf8aa4102694d82b2a449b5924485d6dbae24f2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ pre-commit = "^4.2.0"
 isort = "^6.0.1"
 pylint = "^3.3.6"
 pylint-per-file-ignores = "^1.4.0"
+pyrefly = "^1.2.0"
 mdformat = "^1.0.0"
 mdformat-mkdocs = "^5.3.0"
 

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -1,0 +1,40 @@
+# This is a pyrefly config for the use of OSS developers at Google.
+# This configuration is intended to provide a closest configuration to the
+# current g3 pyrefly.
+python-version = "3.13"
+
+# set the directory Pyrefly will search for files to type check
+project-includes = ["smart_control"]
+
+# exclude generated code and non-library examples from project checks
+project-excludes = [
+  "smart_control/proto",
+  "**/*_pb2.py",
+  "smart_control/notebooks",
+]
+
+# manually set the `sys.platform` Pyrefly will assume when type checking
+python-platform = "linux"
+
+# LINT.IfChange(pyrefly_oss_config)
+infer-with-first-use = false
+check-unannotated-defs = true
+infer-return-types = "never"
+
+# a table mapping error codes to an `is-enabled` boolean
+[errors]
+implicit-import = false
+unused-coroutine = false
+protocol-implicitly-defined-attribute = false
+redundant-condition = false
+unreachable = false
+unsafe-overlap = false
+redefinition = false
+bad-dunder-all = false
+bad-override-mutable-attribute = false
+bad-override-param-name = false
+abstract-method-call = false
+# LINT.ThenChange(
+#  [//depot/google3/third_party/pyrefly/pyrefly/lib/commands/util.rs:pytype_non_parity_errors](https://source.corp.google.com/piper///depot/google3/third_party/pyrefly/pyrefly/lib/commands/util.rs?q=%22LINT.IfChange%28pytype_non_parity_errors%29%22+case:yes),
+#  [//depot/google3/third_party/pyrefly/pyrefly/lib/commands/util.rs:pytype_non_parity_command_line_arguments](https://source.corp.google.com/piper///depot/google3/third_party/pyrefly/pyrefly/lib/commands/util.rs?q=%22LINT.IfChange%28pytype_non_parity_command_line_arguments%29%22+case:yes)
+#)


### PR DESCRIPTION
Addresses google/sbsim#174.

## Summary
- add the Google OSS Pyrefly configuration for `smart_control`
- add Pyrefly to the Poetry dev dependency group and regenerate `poetry.lock`
- run Pyrefly from GitHub Actions and pre-commit hooks in report-only mode
- document the new type-checking workflow for contributors

## Notes
Pyrefly currently reports existing findings in the repository, so this PR wires the check in as non-blocking for now. This matches the discussion in #174/#175 about landing the tooling before the upcoming internal sync-out resolves the current findings. The TODO comments mark the CI and pre-commit places where `|| true` / report-only behavior can be removed later.

## Validation
- `poetry lock`
- `poetry check` (passes with existing Poetry deprecation warnings)
- `pyrefly check --config pyrefly.toml` (command/config verified; reports existing findings)